### PR TITLE
fix: styling language dropdown for mobile browser

### DIFF
--- a/src/components/common/LocaleChanger.vue
+++ b/src/components/common/LocaleChanger.vue
@@ -1,14 +1,12 @@
 <template>
-
-  <div
-    class="tw-px-1.5 tw-rounded-lg tw-border tw-border-gray-300 dark:tw-border-darkGray-600 tw-bg-white dark:tw-bg-darkGray-900"
-  >
-    <select
-      class="tw-justify-center tw-px-1 tw-py-1.5 tw-bg-white dark:tw-bg-darkGray-900 tw-text-xs tw-font-medium tw-text-gray-700 dark:tw-text-darkGray-100 tw-cursor-pointer focus:tw-outline-none"
-      v-model="$i18n.locale"
-    >
-      <option v-for="(lang, i) in langs" :key="`Lang${i}`" :value="lang.code">{{ lang.text }}</option>
+  <div class="tw-relative tw-inline-block tw-border tw-border-gray-300 dark:tw-border-darkGray-600 tw-rounded-lg tw-bg-white dark:tw-bg-darkGray-900">
+    <select class="tw-w-full tw-h-8 tw-pl-3 tw-pr-6 tw-text-s tw-rounded-lg tw-appearance-none tw-bg-white dark:tw-bg-darkGray-900 tw-font-medium tw-text-gray-700 dark:tw-text-darkGray-100 tw-cursor-pointer focus:tw-outline-none hover:tw-bg-gray-100 dark:hover:tw-bg-darkGray-700" placeholder="Regular input" v-model="$i18n.locale">
+        <option v-for="(lang, i) in langs" :key="`Lang${i}`" :value="lang.code">{{ lang.text }}</option>
     </select>
+
+    <div class="tw-absolute tw-inset-y-0 tw-right-0 tw-flex tw-items-center tw-px-2 tw-pointer-events-none dark:tw-text-darkGray-100">
+      <svg class="tw-w-4 tw-h-4 tw-fill-current" viewBox="0 0 20 20"><path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" fill-rule="evenodd"></path></svg>
+    </div>
   </div>
 </template>
 
@@ -22,3 +20,9 @@ export default defineComponent({
   }
 });
 </script>
+
+<style scoped>
+.dropdown:hover .dropdown-menu {
+  display: block;
+}
+</style>


### PR DESCRIPTION
**Pull Request Summary**

Before:
<img width="237" alt="image" src="https://user-images.githubusercontent.com/92044428/136644855-c39eda3b-a6e6-44e1-97a6-b867f899cfea.png">


After:
<img width="467" alt="image" src="https://user-images.githubusercontent.com/92044428/136644860-cce596a3-4167-45d4-9e73-a069d3079687.png">


**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- Language selector dropdown

**Changes**
- Remove hover effect

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)