### PR TITLE
fix: syling mismatched in the TAB

### DIFF
--- a/src/components/common/SidebarCommon.vue
+++ b/src/components/common/SidebarCommon.vue
@@ -36,7 +36,6 @@
             : 'inactiveLink',
         ]"
         class="tw-items-center tw-justify-center"
-        style="height: 104px"
       >
         <icon-base
           :class="[

--- a/src/components/common/Tab.vue
+++ b/src/components/common/Tab.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="tw--mb-px tw-flex tw-justify-items-center" aria-label="Tabs">
+  <nav class="tw--mb-px tw-flex tw-justify-items-center sm:tw-ml-8 md:tw-ml-0" aria-label="Tabs">
     <router-link
       append
       v-for="num in labelsNumArray"
@@ -42,9 +42,9 @@ export default defineComponent({
       inactiveLinkClass:
         'tw-border-gray-50 dark:tw-border-darkGray-900 tw-border tw-rounded-t-md',
       activeSpanClass:
-        'tw-block tw-bg-gray-50 dark:tw-bg-darkGray-900 tw--mb-px tw-whitespace-nowrap tw-py-3 sm:tw-py-5 tw-px-3 md:tw-px-8 tw-text-blue-900 dark:tw-text-darkGray-300 tw-font-medium tw-rounded-t-md tw-border-gray-50 dark:tw-border-darkGray-900 tw-border-b',
+        'tw-block tw-bg-gray-50 dark:tw-bg-darkGray-900 tw--mb-px tw-whitespace-nowrap tw-py-3 sm:tw-py-5 tw-px-6 md:tw-px-8 tw-text-blue-900 dark:tw-text-darkGray-300 tw-font-medium tw-rounded-t-md tw-border-gray-50 dark:tw-border-darkGray-900 tw-border-b',
       inactiveSpanClass:
-        'tw-block tw-bg-gray-50 dark:tw-bg-darkGray-900 tw--mb-px tw-whitespace-nowrap tw-py-3 sm:tw-py-5 tw-px-3 md:tw-px-8 tw-text-blue-500 dark:tw-text-blue-400 tw-font-medium tw-rounded-t-md tw-border-gray-200 dark:tw-border-darkGray-600 tw-border-b hover:tw-text-blue-400 dark:hover:tw-text-blue-300',
+        'tw-block tw-bg-gray-50 dark:tw-bg-darkGray-900 tw--mb-px tw-whitespace-nowrap tw-py-3 sm:tw-py-5 tw-px-6 md:tw-px-8 tw-text-blue-500 dark:tw-text-blue-400 tw-font-medium tw-rounded-t-md tw-border-gray-200 dark:tw-border-darkGray-600 tw-border-b hover:tw-text-blue-400 dark:hover:tw-text-blue-300',
     });
     const labelsNumArray = computed(() => [
       ...Array(props.labels.length).keys(),

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -92,6 +92,7 @@ export default {
     },
   },
   store: {
+    dappsStore: 'dApps Store',
     registerDapp: 'Register dApp',
     noDappsRegistered: 'No dApps registered. Be a first to register one.',
     totalStake: 'Total stake:',

--- a/src/i18n/ja/index.ts
+++ b/src/i18n/ja/index.ts
@@ -92,6 +92,7 @@ export default {
     },
   },
   store: {
+    dappsStore: 'dApps Store',
     registerDapp: 'dAppを登録',
     noDappsRegistered: 'No dApps registered. Be a first to register one.',
     totalStake: 'Total stake:',

--- a/src/i18n/zh-TW/index.ts
+++ b/src/i18n/zh-TW/index.ts
@@ -92,6 +92,7 @@ export default {
     },
   },
   store: {
+    dappsStore: 'dApps Store',
     registerDapp: '註冊dApp',
     noDappsRegistered: 'No dApps registered. Be a first to register one.',
     totalStake: '總質押:',

--- a/src/i18n/zh/index.ts
+++ b/src/i18n/zh/index.ts
@@ -92,6 +92,7 @@ export default {
     },
   },
   store: {
+    dappsStore: 'dApps Store',
     registerDapp: '注册dApp',
     noDappsRegistered: 'No dApps registered. Be a first to register one.',
     totalStake: '总质押:',

--- a/src/pages/Balance.vue
+++ b/src/pages/Balance.vue
@@ -5,7 +5,7 @@
     <h1
       class="md:tw-mr-10 tw-text-3xl tw-font-extrabold tw-text-blue-900 dark:tw-text-white tw-mb-6 sm:tw-mb-8"
     >
-      Balance
+      {{$t('balance.balance')}}
     </h1>
     <Tab
       :labels="[

--- a/src/pages/DApps.vue
+++ b/src/pages/DApps.vue
@@ -5,7 +5,7 @@
     <h1
       class="md:tw-mr-10 tw-text-3xl tw-font-extrabold tw-text-blue-900 dark:tw-text-white tw-mb-6 sm:tw-mb-8"
     >
-      dApps
+      {{$t('common.dApps')}}
     </h1>
     <Tab
       :labels="[

--- a/src/pages/Store.vue
+++ b/src/pages/Store.vue
@@ -5,19 +5,23 @@
     <h1
       class="md:tw-mr-10 tw-text-3xl tw-font-extrabold tw-text-blue-900 dark:tw-text-white tw-mb-6 sm:tw-mb-8"
     >
-      dApps Store
+      {{$t('store.dappsStore')}}
     </h1>
-    <Tab
-      :labels="[
-        { label: 'Discover', path: 'discover-dapps' },
-      ]"
-    />
-    <Tab
-      :labels="[
-        { label: 'Manage', path: 'manage-dapps' },
-      ]"
-    />
-  </div>
+      <div
+        class="tw-flex"
+      >
+        <Tab
+          :labels="[
+            { label: 'Discover', path: 'discover-dapps' },
+          ]"
+        />
+        <Tab
+          :labels="[
+            { label: 'Manage', path: 'manage-dapps' },
+          ]"
+        />
+      </div>
+    </div>
   <router-view />
 </template>
 


### PR DESCRIPTION
**Pull Request Summary**

* Unified the Tabs high which reported in [this](https://github.com/PlasmNetwork/astar-apps/issues/42) issue
* Fixed the styling bug in dApps store page 
* Fixed margin between page title and tabs for smaller device screen

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- Please refer to the attached screen shot

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)

=Before=
![image](https://user-images.githubusercontent.com/92044428/136682667-41c1b4e2-38bd-42de-8578-f65a1915efe9.png)


=After=
![image](https://user-images.githubusercontent.com/92044428/136682699-ae4e2321-0cf3-4a3f-9a36-5998496b91bd.png)

=Before | After=
Width: 375px
![image](https://user-images.githubusercontent.com/92044428/136682871-fde56f65-19c4-4fe7-b8dc-78cc95e85eaf.png)

Width: 724px
![image](https://user-images.githubusercontent.com/92044428/136682912-e3ce4505-134b-462f-9af6-9389e3aa16b5.png)
