### PR TITLE
fix: remove the default 0 value in the `InputAmount`

### DIFF
--- a/src/components/common/InputAmount.vue
+++ b/src/components/common/InputAmount.vue
@@ -18,8 +18,8 @@
             type="number"
             min="0"
             pattern="^[0-9]*(\.)?[0-9]*$"
-            placeholder="0.0"
-            :value="amount"
+            placeholder="0"
+            :value="Number(amount) ? amount : null"
             @input="update($event.target.value, selectedUnit)"
           />
         </div>


### PR DESCRIPTION
**Pull Request Summary**

Remove the default `0` value from `InputAmount`.

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- Please refer to attached screenshot
- Cast to `Number(amount)` because the amount type is 'BigNumber' for Balance UI but 'Number' for Store UI   

```
:value="Number(amount) ? amount : null"
```

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)

=Before=
User has to delete '0' when input the value

![image](https://user-images.githubusercontent.com/92044428/137160422-b4677d5d-3660-4af8-bfbc-4d1f60e8e3c2.png)

Gif:
https://gyazo.com/301d3623278904891bde1e90768eb872

=After=
Only the placeholder '0' should be enough. 

![image](https://user-images.githubusercontent.com/92044428/137160340-a2cdf726-6d4d-4334-bfb8-500085a8b1d4.png)

Gif:
https://gyazo.com/84c9b68f481c082c241c56e78db93e7b