### PR TITLE
fix: remove space before 'extension' in account UI

### DIFF
--- a/src/config/api/polkadot/connectApi.ts
+++ b/src/config/api/polkadot/connectApi.ts
@@ -58,12 +58,12 @@ export async function connectApi(endpoint: string, networkIdx: number) {
   let extensions: InjectedExtension[] = [];
 
   const typeDefinitions = providerEndpoints[networkIdx].typeDef;
-  console.log('t', typeDefinitions)
+  console.log('t', typeDefinitions);
 
   const api = new ApiPromise({
     provider,
     types: {
-      ...typeDefinitions
+      ...typeDefinitions,
     },
   });
 
@@ -87,15 +87,21 @@ export async function connectApi(endpoint: string, networkIdx: number) {
       keyring.accounts.subject.subscribe((accounts) => {
         if (accounts) {
           store.commit('general/setAllAccounts', Object.keys(accounts));
-          store.commit('general/setAllAccountNames', Object.values(accounts).map((obj) => obj.option.name));
+          // Memo: remove space from UI.
+          store.commit(
+            'general/setAllAccountNames',
+            Object.values(accounts).map((obj) =>
+              obj.option.name.replace('\n              ', '')
+            )
+          );
         }
       });
       //subscription.unsubscribe();
-  
+
       store.commit('general/setCurrentNetworkStatus', 'connected');
     } catch (err) {
       console.error(err);
-  
+
       store.commit('general/setCurrentNetworkStatus', 'offline');
     }
   });


### PR DESCRIPTION
**Pull Request Summary**

Removed unnecessarily space from the account UI.

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- Please refer to the attached screenshot

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)

=Before=
![image](https://user-images.githubusercontent.com/92044428/137171351-a09d0447-a7ca-4f0c-b633-08be495c7027.png)

=After=
![image](https://user-images.githubusercontent.com/92044428/137171440-323bbb62-d18c-4e0b-89d9-33399aa0b6eb.png)
