### PR TITLE
fix: font-size for 'Vested' and 'Locked'

### DIFF
--- a/src/components/balance/PlmBalance.vue
+++ b/src/components/balance/PlmBalance.vue
@@ -62,7 +62,7 @@
         <div>{{ $t('balance.vested') }}</div>
         <div>
           <p class="tw-font-bold tw-text-right">
-            <span class="tw-text-2xl tw-leading-tight">
+            <span class="tw-text-2xl md:tw-text-xl xl:tw-text-2xl tw-leading-tight">
               <format-balance :balance="accountData?.vested" />
             </span>
           </p>


### PR DESCRIPTION
**Pull Request Summary**

standardize the font-size of 'Vested' and 'Locked'

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)

=Before=
![image](https://user-images.githubusercontent.com/92044428/137356116-76ed81c4-cf56-4466-8c5f-214d4e207bf7.png)

=After=
![image](https://user-images.githubusercontent.com/92044428/137356146-b85b879c-4188-4d51-a3cc-fa7ba1cafd99.png)
