### PR TITLE
fix: margin in Balance page

### DIFF
--- a/src/components/balance/BalancePlasm.vue
+++ b/src/components/balance/BalancePlasm.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="isConnected(currentNetworkStatus)">
-    <div class="tw-grid md:tw-auto-cols-max xl:tw-grid-cols-2 tw-gap-4 tw-mb-4">
+    <div class="tw-grid md:tw-auto-cols-max xl:tw-grid-cols-2 tw-gap-4 tw-mb-8">
       <Address
         v-model:isOpen="modalAccount"
         :address="currentAccount"


### PR DESCRIPTION
**Pull Request Summary**

Standardize the margin gap in Balance page 

Issue: https://github.com/PlasmNetwork/astar-apps/issues/95

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- Please refer to the attached screen shot

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)

Both margin bottom are fixed as 32px

![Screenshot 2021-10-19 at 12 32 30 AM](https://user-images.githubusercontent.com/92044428/137772584-4e493da9-ddc5-4955-ad2f-c06da6c7ddf0.png)

![Screenshot 2021-10-19 at 12 32 11 AM](https://user-images.githubusercontent.com/92044428/137772622-5fe9ce18-a0e0-40cd-a53a-0a426b9dea6c.png)
