### PR TITLE
fix: allow to input start from 0

### DIFF
--- a/src/components/common/InputAmount.vue
+++ b/src/components/common/InputAmount.vue
@@ -37,8 +37,9 @@
             min="0"
             pattern="^[0-9]*(\.)?[0-9]*$"
             placeholder="0"
-            :value="Number(amount) ? amount : null"
+            :value="isInitInput && amount"
             @input="update($event.target.value, selectedUnit)"
+            @focus="initInput"
           />
         </div>
         <div
@@ -87,11 +88,12 @@ export default defineComponent({
     selectedUnit: { type: String, default: '' },
     maxInDefaultUnit: { type: Object as PropType<BN>, default: new BN(0) },
     fixUnit: { type: Boolean, default: false },
-    amount: { required: true, type: Object as PropType<BN> },
+    amount: { default: new BN(0), type: (Object as PropType<BN>) || Number },
   },
   emits: ['update:amount', 'update:selectedUnit', 'input'],
   setup(props, { emit }) {
     const isMaxAmount = ref<boolean>(false);
+    const isInitInput = ref<boolean>(false);
     const arrUnitNames = getUnitNames();
     const update = (amount: BN, unit: string | undefined) => {
       emit('update:amount', amount);
@@ -114,7 +116,25 @@ export default defineComponent({
       isMaxAmount.value = false;
     });
 
-    return { arrUnitNames, update, isMaxAmount };
+    const initInput = () => {
+      // Memo: Remove default props.amount->(0) from input when initialised
+      // Memo: props.amout is defined by BN or Number from parent components
+      try {
+        if (props.amount.eq(new BN(0))) {
+          emit('update:amount', '');
+        }
+      } catch (e) {
+        if (new BN(props.amount).eq(new BN(0))) {
+          emit('update:amount', '');
+        }
+      }
+
+      if (!isInitInput.value) {
+        isInitInput.value = true;
+      }
+    };
+
+    return { arrUnitNames, update, isMaxAmount, isInitInput, initInput };
   },
 });
 </script>


### PR DESCRIPTION
**Pull Request Summary**

Allow user to input start from '0' such as '0.1'.

Relative: https://github.com/PlasmNetwork/astar-apps/pull/75

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Fixes**
=Before=
Input field doesn't accept typing start from '0'.

=Before=
![image](https://user-images.githubusercontent.com/92044428/138208220-0fa62209-c335-46ad-91b2-b6a066ad3241.png)


=After=
![image](https://user-images.githubusercontent.com/92044428/138208038-9a49a6a6-99f6-4ff3-a50e-742c192783bc.png)
