### PR TITLE
Use chain name as firebase collection key, improved error handling

### DIFF
--- a/src/hooks/firebase/index.ts
+++ b/src/hooks/firebase/index.ts
@@ -13,11 +13,11 @@ import { DappItem, NewDappItem } from 'src/store/dapps-store/state';
 
 // firebase init - add your own config here
 const firebaseConfig = {
-  apiKey: 'AIzaSyA0z54GGpR59uOzb-I4aNDCmvC1S1UO24E',
+  apiKey: 'AIzaSyBS6tU69xQAnfWfI4U9vmErJ7qBDnO7MOI',
   authDomain: '',
   databaseURL: '',
-  projectId: 'dapp-store-7f9ab',
-  storageBucket: 'gs://dapp-store-7f9ab.appspot.com',
+  projectId: 'astarnetwork-a4924',
+  storageBucket: 'gs://astarnetwork-a4924.appspot.com',
   messagingSenderId: '',
   appId: '',
 };
@@ -46,8 +46,8 @@ const addDapp = async (collectionName: string, dapp: NewDappItem): Promise<DappI
   return newDapp;
 };
 
-const uploadFile = async (fileName: string, base64Content: string) => {
-  const imagesRef = ref(storage, `images/${fileName}`);
+const uploadFile = async (fileName: string, collectionKey: string, base64Content: string) => {
+  const imagesRef = ref(storage, `${collectionKey}/${fileName}`);
   const result = await uploadString(imagesRef, base64Content, 'data_url');
   const url = await getDownloadURL(ref(storage, result.metadata.fullPath));
 


### PR DESCRIPTION
**Pull Request Summary**

Main change is switch to the company firebase and uses chain name as storage key so we can easily switch rpc endpoints

Imported all Shibuya, Shidden dapps to the new storage. Before merging this PR need to check if some dapp is added to the store in the meantime.

**Check list**
- [ ] contains breaking changes
- [x] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- switch to company firebase
- Use chain name as firebase key

**Fixes**
- register dapp error handling

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)