### PR TITLE
fix: change word and color for Claim modal button

### DIFF
--- a/src/components/store/StakePanel.vue
+++ b/src/components/store/StakePanel.vue
@@ -28,13 +28,8 @@
           {{ $t('store.stake') }}
         </Button>
 
-        <Button
-          :small="true"
-          :primary="false"
-          class="tw-ml-auto"
-          @click="showClaimRewardModal = true"
-        >
-          {{ $t('store.claim') }}
+        <Button :small="true" class="tw-ml-auto" @click="showClaimRewardModal = true">
+          {{ $t('store.view') }}
         </Button>
       </div>
     </div>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -108,6 +108,7 @@ export default {
     unstake: 'Unstake',
     stake: 'Stake',
     claim: 'Claim',
+    view: 'View',
     minimumStakingAmount: 'Min. staking amount',
     maxNumberOfStakersPerContract: 'Max. stakers per contract',
     stakersCount: 'Stakers:',

--- a/src/i18n/ja/index.ts
+++ b/src/i18n/ja/index.ts
@@ -103,6 +103,7 @@ export default {
     unstake: 'Unstake',
     stake: 'Stake',
     claim: '報酬',
+    view: '詳細',
     modals: {
       alreadyClaimed: 'Already claimed:',
       contractRewards: 'Contract rewards:',

--- a/src/i18n/zh-TW/index.ts
+++ b/src/i18n/zh-TW/index.ts
@@ -103,6 +103,7 @@ export default {
     unstake: '解除質押',
     stake: '質押',
     claim: '認領',
+    view: '查看',
     modals: {
       alreadyClaimed: '已認領:',
       contractRewards: '合約報酬:',

--- a/src/i18n/zh/index.ts
+++ b/src/i18n/zh/index.ts
@@ -103,6 +103,7 @@ export default {
     unstake: '解除质押',
     stake: '质押',
     claim: '认领',
+    view: '查看',
     modals: {
       alreadyClaimed: '已认领:',
       contractRewards: '合约报酬:',


### PR DESCRIPTION
**Pull Request Summary**

Modified word, translation and color for 'Claim modal' button.

Issue: https://github.com/PlasmNetwork/astar-apps/issues/118

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Changes**
- (ex: Change document B)

=Before=
<img width="333" alt="image" src="https://user-images.githubusercontent.com/92044428/139018913-cf296cf9-9cc7-4986-92ed-0bd622a8ac82.png">

=After=
<img width="325" alt="image" src="https://user-images.githubusercontent.com/92044428/139102474-db290abc-89d6-4e59-b395-d362229e2dda.png">

