### PR TITLE
Set nonce for transactions

### DIFF
--- a/src/components/common/DashboardItem.vue
+++ b/src/components/common/DashboardItem.vue
@@ -8,7 +8,7 @@
       tw-p-4
     "
   >
-    <div class="tw-text-center tw-font-semibold tw-text-xl tw-my-1">{{ value }}</div>
+    <div class="tw-text-center tw-font-semibold tw-text-2xl tw-my-1">{{ value }}</div>
     <div class="tw-text-center">{{ caption }}</div>
   </div>
 </template>

--- a/src/components/store/DiscoverDappsTab.vue
+++ b/src/components/store/DiscoverDappsTab.vue
@@ -10,7 +10,7 @@
       </icon-base>
       {{ $t('store.registerDapp') }}
     </Button>
-    <div class="tw-flex tw-flex-row tw-content-around">
+    <div class="tw-flex tw-flex-row tw-flex-wrap tw-content-around">
       <DashboardItem :value="minimumStakingAmount" :caption="$t('store.minimumStakingAmount')" />
       <DashboardItem
         :value="maxNumberOfStakersPerContract"

--- a/src/store/dapps-store/actions.ts
+++ b/src/store/dapps-store/actions.ts
@@ -190,6 +190,7 @@ const actions: ActionTree<State, StateInterface> = {
             parameters.senderAddress,
             {
               signer: injector?.signer,
+              nonce: -1,
             },
             async (result) => {
               if (result.status.isFinalized) {
@@ -257,12 +258,14 @@ const actions: ActionTree<State, StateInterface> = {
     try {
       if (parameters.api) {
         const injector = await web3FromSource('polkadot-js');
+        // const nonce = await parameters.api.rpc.system.accountNextIndex(parameters.senderAddress);
         const unsub = await parameters.api.tx.dappsStaking
           .bondAndStake(getAddressEnum(parameters.dapp.address), parameters.amount)
           .signAndSend(
             parameters.senderAddress,
             {
               signer: injector?.signer,
+              nonce: -1,
             },
             (result) => {
               if (result.status.isFinalized) {
@@ -313,6 +316,7 @@ const actions: ActionTree<State, StateInterface> = {
             parameters.senderAddress,
             {
               signer: injector?.signer,
+              nonce: -1,
             },
             (result) => {
               if (result.status.isFinalized) {
@@ -384,6 +388,7 @@ const actions: ActionTree<State, StateInterface> = {
           parameters.senderAddress,
           {
             signer: injector?.signer,
+            nonce: -1,
           },
           (result) => {
             if (result.isFinalized) {


### PR DESCRIPTION
**Pull Request Summary**

> I was unable to reproduce the issue while running a single portal instance, since we are blocking UI until transaction finish. I managed to reproduce the issue by submitting the same transaction from portal running in multiple tabs. I don't see how we can guard that.

Just in case I added nonce to all dapp store transaction as suggested here https://polkadot.js.org/docs/api/cookbook/tx/#how-do-i-take-the-pending-tx-pool-into-account-in-my-nonce 

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- nonce to dapp store transactions

