### PR TITLE
fix: Unable to close 'register dApp' modal bug

### DIFF
--- a/src/components/balance/modals/ModalAccount.vue
+++ b/src/components/balance/modals/ModalAccount.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto">
+  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto" @click="closeModal">
     <div class="tw-flex tw-items-center tw-justify-center tw-min-h-screen">
       <!-- Background overlay -->
       <div class="tw-fixed tw-inset-0 tw-transition-opacity" aria-hidden="true">
@@ -22,6 +22,7 @@
           tw-max-w-lg
           tw-w-full
         "
+        @click.stop
       >
         <div>
           <div>

--- a/src/components/balance/modals/ModalFaucet.vue
+++ b/src/components/balance/modals/ModalFaucet.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto">
+  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto" @click="closeModal">
     <div class="tw-flex tw-items-center tw-justify-center tw-min-h-screen">
       <!-- Background overlay -->
       <div class="tw-fixed tw-inset-0 tw-transition-opacity" aria-hidden="true">
@@ -22,6 +22,7 @@
           tw-max-w-lg
           tw-w-full
         "
+        @click.stop
       >
         <div>
           <h3

--- a/src/components/balance/modals/ModalNetwork.vue
+++ b/src/components/balance/modals/ModalNetwork.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto">
+  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto" @click="closeModal">
     <div class="tw-flex tw-items-center tw-justify-center tw-min-h-screen">
       <!-- Background overlay -->
       <div class="tw-fixed tw-inset-0 tw-transition-opacity" aria-hidden="true">
@@ -23,6 +23,7 @@
           tw-max-w-lg
           tw-w-full
         "
+        @click.stop
       >
         <div>
           <div>

--- a/src/components/balance/modals/ModalTransferAmount.vue
+++ b/src/components/balance/modals/ModalTransferAmount.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto">
+  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto" @click="closeModal">
     <div class="tw-flex tw-items-center tw-justify-center tw-min-h-screen">
       <!-- Background overlay -->
       <div class="tw-fixed tw-inset-0 tw-transition-opacity" aria-hidden="true">
@@ -22,6 +22,7 @@
           tw-max-w-lg
           tw-w-full
         "
+        @click.stop
       >
         <div>
           <q-banner

--- a/src/components/balance/modals/ModalWithdrawalEvmDeposit.vue
+++ b/src/components/balance/modals/ModalWithdrawalEvmDeposit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto">
+  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto" @click="closeModal">
     <div class="tw-flex tw-items-center tw-justify-center tw-min-h-screen">
       <!-- Background overlay -->
       <div class="tw-fixed tw-inset-0 tw-transition-opacity" aria-hidden="true">
@@ -22,6 +22,7 @@
           tw-max-w-lg
           tw-w-full
         "
+        @click.stop
       >
         <div>
           <h3

--- a/src/components/common/Modal.vue
+++ b/src/components/common/Modal.vue
@@ -39,10 +39,6 @@
             </div>
           </div>
         </div>
-        <div class="tw-mt-6 tw-flex tw-justify-center tw-flex-row">
-          <Button type="button" :primary="false" @click="closeModal">{{ $t('close') }}</Button>
-          <slot name="buttons"></slot>
-        </div>
       </div>
     </div>
   </div>
@@ -50,27 +46,17 @@
 
 <script lang="ts">
 import { defineComponent, toRefs } from 'vue';
-import Button from 'src/components/common/Button.vue';
 
 export default defineComponent({
-  components: {
-    Button,
-  },
   props: {
     title: {
       type: String,
       default: '',
     },
   },
-  emits: ['update:is-open'],
-  setup(props, { emit }) {
-    const closeModal = () => {
-      emit('update:is-open', false);
-    };
-
+  setup(props) {
     return {
       ...toRefs(props),
-      closeModal,
     };
   },
 });

--- a/src/components/common/Modal.vue
+++ b/src/components/common/Modal.vue
@@ -22,6 +22,7 @@
           tw-max-w-lg
           tw-w-full
         "
+        @click.stop
       >
         <div>
           <div>

--- a/src/components/contracts/modals/ModalCodeHash.vue
+++ b/src/components/contracts/modals/ModalCodeHash.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto">
+  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto" @click="closeModal">
     <div class="tw-flex tw-items-center tw-justify-center tw-min-h-screen">
       <!-- Background overlay -->
       <div class="tw-fixed tw-inset-0 tw-transition-opacity" aria-hidden="true">
@@ -23,6 +23,7 @@
           tw-max-w-lg
           tw-w-full
         "
+        @click.stop
       >
         <div>
           <div>

--- a/src/components/contracts/modals/ModalCreateDapps.vue
+++ b/src/components/contracts/modals/ModalCreateDapps.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto">
+  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto" @click="closeModal">
     <div class="tw-flex tw-items-center tw-justify-center tw-min-h-screen">
       <!-- Background overlay -->
       <div class="tw-fixed tw-inset-0 tw-transition-opacity" aria-hidden="true">
@@ -23,6 +23,7 @@
           tw-max-w-4xl
           tw-w-full
         "
+        @click.stop
       >
         <div>
           <h3

--- a/src/components/dapp-staking/modals/ClaimRewardModal.vue
+++ b/src/components/dapp-staking/modals/ClaimRewardModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Modal :title="`Claim reward ${dapp.name}`">
+  <Modal :title="`Claim reward ${dapp.name}`" @click="closeModal">
     <template #content>
       <Avatar :url="dapp.iconUrl" class="tw-w-36 tw-h-36 tw-mb-4 tw-mx-auto" />
       <div v-if="stakeInfo?.totalStake" class="tw-mt-4">

--- a/src/components/dapp-staking/modals/ClaimRewardModal.vue
+++ b/src/components/dapp-staking/modals/ClaimRewardModal.vue
@@ -28,11 +28,12 @@
           claimInfo?.unclaimedEras?.length
         }}</span>
       </div>
-    </template>
-    <template #buttons>
-      <Button :disabled="!canClaim" class="tw-tooltip" @click="claimAction()">
-        {{ $t('dappStaking.claim') }}
-      </Button>
+      <div class="tw-mt-6 tw-flex tw-justify-center tw-flex-row">
+        <Button type="button" :primary="false" @click="closeModal">{{ $t('close') }}</Button>
+        <Button :disabled="!canClaim" class="tw-tooltip" @click="claimAction()">
+          {{ $t('dappStaking.claim') }}
+        </Button>
+      </div>
     </template>
   </Modal>
 </template>
@@ -47,7 +48,6 @@ import Button from 'src/components/common/Button.vue';
 import Avatar from 'src/components/common/Avatar.vue';
 import { StakingParameters, ClaimInfo } from 'src/store/dapp-staking/actions';
 import { balanceFormatter } from 'src/hooks/helper/plasmUtils';
-import BN from 'bn.js';
 
 export default defineComponent({
   components: {
@@ -69,7 +69,8 @@ export default defineComponent({
       required: true,
     },
   },
-  setup(props) {
+  emits: ['update:is-open'],
+  setup(props, { emit }) {
     const { api } = useApi();
     const store = useStore();
     const { decimal } = useChainMetadata();
@@ -94,11 +95,16 @@ export default defineComponent({
       claimedRewards.value = balanceFormatter(claimInfo.value.estimatedClaimedRewards.toString());
     });
 
+    const closeModal = () => {
+      emit('update:is-open', false);
+    };
+
     return {
       pendingRewards,
       claimedRewards,
       claimInfo,
       canClaim,
+      closeModal,
       ...toRefs(props),
     };
   },

--- a/src/components/dapp-staking/modals/ModalRegisterDapp.vue
+++ b/src/components/dapp-staking/modals/ModalRegisterDapp.vue
@@ -1,5 +1,5 @@
 <template>
-  <Modal title="Register a new dApp">
+  <Modal title="Register a new dApp" @click="closeModal">
     <template #content>
       <div>
         <div class="tw-mb-4">

--- a/src/components/dapp-staking/modals/ModalRegisterDapp.vue
+++ b/src/components/dapp-staking/modals/ModalRegisterDapp.vue
@@ -53,9 +53,10 @@
         />
         <Input v-model="data.url" label="Url" type="text" maxlength="1000" />
       </div>
-    </template>
-    <template #buttons>
-      <Button @click="registerDapp">{{ $t('dappStaking.modals.register') }}</Button>
+      <div class="tw-mt-6 tw-flex tw-justify-center tw-flex-row">
+        <Button type="button" :primary="false" @click="closeModal">{{ $t('close') }}</Button>
+        <Button @click="registerDapp">{{ $t('dappStaking.modals.register') }}</Button>
+      </div>
     </template>
   </Modal>
 </template>
@@ -119,6 +120,10 @@ export default defineComponent({
       if (result) {
         emit('update:is-open', false);
       }
+    };
+
+    const closeModal = () => {
+      emit('update:is-open', false);
     };
 
     const encodeImage = (fileType: string, data: Uint8Array): string => {
@@ -187,6 +192,7 @@ export default defineComponent({
       validationErrors,
       onDropFile,
       registerDapp,
+      closeModal,
     };
   },
 });

--- a/src/components/dapp-staking/modals/StakeModal.vue
+++ b/src/components/dapp-staking/modals/StakeModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Modal :title="title">
+  <Modal :title="title" @click="closeModal">
     <template #content>
       <Avatar :url="dapp.iconUrl" class="tw-w-36 tw-h-36 tw-mb-4 tw-mx-auto" />
       <div class="tw-mb-4">

--- a/src/components/dapp-staking/modals/StakeModal.vue
+++ b/src/components/dapp-staking/modals/StakeModal.vue
@@ -40,9 +40,10 @@
         {{ $t('dappStaking.yourStake') }}
         <format-balance :balance="stakeAmount" class="tw-inline tw-font-semibold" />
       </div>
-    </template>
-    <template #buttons>
-      <Button :disabled="!canExecuteAction" @click="action(data)">{{ actionName }}</Button>
+      <div class="tw-mt-6 tw-flex tw-justify-center tw-flex-row">
+        <Button type="button" :primary="false" @click="closeModal">{{ $t('close') }}</Button>
+        <Button :disabled="!canExecuteAction" @click="action(data)">{{ actionName }}</Button>
+      </div>
     </template>
   </Modal>
 </template>
@@ -101,7 +102,8 @@ export default defineComponent({
       required: true,
     },
   },
-  setup(props) {
+  emits: ['update:is-open'],
+  setup(props, { emit }) {
     const store = useStore();
     const { decimal, defaultUnitToken } = useChainMetadata();
 
@@ -140,6 +142,10 @@ export default defineComponent({
       store.commit('general/setCurrentAccountIdx', selAccountIdx);
     };
 
+    const closeModal = () => {
+      emit('update:is-open', false);
+    };
+
     return {
       data,
       allAccounts,
@@ -148,6 +154,7 @@ export default defineComponent({
       reloadAmount,
       StakeAction,
       canExecuteAction,
+      closeModal,
       ...toRefs(props),
     };
   },


### PR DESCRIPTION
**Pull Request Summary**

* Fixed unable to close "Register a new dApp" modal bug
* Auto close modal when user clicks outside of it

Describe the bug:
Unable to close "Register a new dApp" modal 
(perhaps because of duplicated emits in [Modal.vue](https://github.com/AstarNetwork/astar-apps/blob/main/src/components/common/Modal.vue#L65) and [ModalRegisterDapp.vue](https://github.com/AstarNetwork/astar-apps/blob/main/src/components/dapp-staking/modals/ModalRegisterDapp.vue#L89))

To Reproduce:
1. Click "Registed dApp" button
2. Click "Close" button

Gif:
Before:
https://gyazo.com/8c192bfd9a85cfbb49146752cae68c3f

After: 
https://gyazo.com/b1775cb42962864caf63659c6d4c5344

https://gyazo.com/47a17553e334b9a3bd905489781fd307

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
