### PR TITLE
fix: disable faucet button when the data is loading

### DIFF
--- a/src/components/balance/BalancePlasm.vue
+++ b/src/components/balance/BalancePlasm.vue
@@ -45,6 +45,7 @@
         v-model:isOpenModalFaucet="modalFaucet"
         :address="currentAccount"
         :account-data="accountData"
+        :is-faucet-loading="isLoading"
       />
     </div>
 
@@ -140,7 +141,7 @@ export default defineComponent({
     const isSS58 = computed(() => store.getters['general/isCheckMetamask']);
     const isH160 = computed(() => store.getters['general/isH160Formatted']);
     const { evmDeposit } = useEvmDeposit();
-    const { faucetInfo, requestFaucet } = useFaucet();
+    const { faucetInfo, requestFaucet, isLoading } = useFaucet();
 
     return {
       ...toRefs(stateModal),
@@ -156,6 +157,7 @@ export default defineComponent({
       isH160,
       faucetInfo,
       requestFaucet,
+      isLoading,
     };
   },
   methods: {

--- a/src/components/balance/PlmBalance.vue
+++ b/src/components/balance/PlmBalance.vue
@@ -59,7 +59,13 @@
             >
               {{ $t('balance.transfer') }}
             </button>
-            <button v-if="!isH160" type="button" class="transfer-button" @click="openFaucetModal">
+            <button
+              v-if="!isH160"
+              type="button"
+              class="transfer-button"
+              :disabled="isFaucetLoading"
+              @click="openFaucetModal"
+            >
               {{ $t('balance.faucet') }}
             </button>
           </div>
@@ -148,6 +154,10 @@ export default defineComponent({
     },
     accountData: {
       type: Object,
+      required: true,
+    },
+    isFaucetLoading: {
+      type: Boolean,
       required: true,
     },
   },


### PR DESCRIPTION
**Pull Request Summary**

* Disable faucet button when the data is loading. (Avoid displaying the initial state information on faucet modal)

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Changes**
- (ex: Change document B)

![image](https://user-images.githubusercontent.com/92044428/148333474-4d966d21-0435-4b68-9e21-ea172a2fb8cc.png)

![image](https://user-images.githubusercontent.com/92044428/148333557-84e33430-b830-45c4-97f6-fa976ca71d08.png)

