### PR TITLE
Unclaimed eras calculation fix

### DIFF
--- a/src/store/dapp-staking/actions.ts
+++ b/src/store/dapp-staking/actions.ts
@@ -130,7 +130,9 @@ const getClaimableEraStakes = async (
       era
     );
 
-    eraStakeMap.set(era, eraStake);
+    if (!eraStake.isEmpty) {
+      eraStakeMap.set(era, eraStake);
+    }
   }
 
   return eraStakeMap;

--- a/src/store/dapp-staking/actions.ts
+++ b/src/store/dapp-staking/actions.ts
@@ -132,6 +132,8 @@ const getClaimableEraStakes = async (
 
     if (!eraStake.isEmpty) {
       eraStakeMap.set(era, eraStake);
+    } else {
+      break;
     }
   }
 


### PR DESCRIPTION
**Pull Request Summary**

> closes #203 

DIA contract was registered in era 60, but because of bug we were trying to claim older eras. 

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Fixes**
- invalid eras to claim calculation.
