### PR TITLE
fix: display messages whenever the user connects mathwallet on networks other than Shiden network

### DIFF
--- a/src/components/balance/modals/ModalAccount.vue
+++ b/src/components/balance/modals/ModalAccount.vue
@@ -133,7 +133,9 @@ export default defineComponent({
       emit('update:is-open', false);
     };
 
-    const selAccount = ref<string>(substrateAccounts.value[0].address);
+    const selAccount = ref<string>(
+      substrateAccounts.value.length ? substrateAccounts.value[0] : ''
+    );
     const isH160Account = ref<boolean>(isH160Formatted.value);
 
     const currentNetworkStatus = computed(() => store.getters['general/networkStatus']);

--- a/src/components/balance/modals/ModalAccount.vue
+++ b/src/components/balance/modals/ModalAccount.vue
@@ -134,7 +134,7 @@ export default defineComponent({
     };
 
     const selAccount = ref<string>(
-      substrateAccounts.value.length ? substrateAccounts.value[0] : ''
+      substrateAccounts.value.length > 0 ? substrateAccounts.value[0] : ''
     );
     const isH160Account = ref<boolean>(isH160Formatted.value);
 


### PR DESCRIPTION
**Pull Request Summary**

* Display messages whenever the user connects Mathwallet(browser extension) on networks other than Shiden network

=Before=
Gif:
https://gyazo.com/64b2a6dd62d1151526bb28ce0807721a

![image](https://user-images.githubusercontent.com/92044428/149777193-9af09b48-6578-44bf-810c-98ba18410e1d.png)

=After=
Gif:
https://gyazo.com/d37a5bd95c9acebd7c56214b232771e6

<img width="714" alt="image" src="https://user-images.githubusercontent.com/92044428/149780895-78ed5356-9b8f-47d4-b677-251520a7abd5.png">


**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)