### PR TITLE
fix: call the faucet HTTP request from faucet modal

### DIFF
--- a/src/components/balance/BalancePlasm.vue
+++ b/src/components/balance/BalancePlasm.vue
@@ -37,7 +37,6 @@
         v-model:isOpenModalFaucet="modalFaucet"
         :address="currentAccount"
         :account-data="accountData"
-        :is-faucet-loading="isLoading"
       />
     </div>
 
@@ -55,12 +54,7 @@
       :account="currentAccount"
       :account-name="currentAccountName"
     />
-    <ModalFaucet
-      v-if="modalFaucet"
-      v-model:isOpen="modalFaucet"
-      :info="faucetInfo"
-      :request-faucet="requestFaucet"
-    />
+    <ModalFaucet v-if="modalFaucet" v-model:isOpen="modalFaucet" />
   </div>
 
   <!-- <ModalAlertBox
@@ -122,7 +116,6 @@ export default defineComponent({
     const currentNetworkStatus = computed(() => store.getters['general/networkStatus']);
     const isH160 = computed(() => store.getters['general/isH160Formatted']);
     const { evmDeposit } = useEvmDeposit();
-    const { faucetInfo, requestFaucet, isLoading } = useFaucet();
 
     return {
       ...toRefs(stateModal),
@@ -133,9 +126,6 @@ export default defineComponent({
       currentNetworkStatus,
       accountData,
       isH160,
-      faucetInfo,
-      requestFaucet,
-      isLoading,
     };
   },
   methods: {

--- a/src/components/balance/PlmBalance.vue
+++ b/src/components/balance/PlmBalance.vue
@@ -78,7 +78,6 @@
               v-if="!isH160"
               type="button"
               class="transfer-button small-button"
-              :disabled="isFaucetLoading"
               @click="openFaucetModal"
             >
               {{ $t('balance.faucet') }}
@@ -220,10 +219,6 @@ export default defineComponent({
     },
     accountData: {
       type: Object as PropType<AccountData>,
-      required: true,
-    },
-    isFaucetLoading: {
-      type: Boolean,
       required: true,
     },
   },


### PR DESCRIPTION
**Pull Request Summary**

Invoke the faucet GET request once user has clicked faucet button (call the request from modal).  It will reduce the GET request to Heroku server.

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Changes**

=Before=
![image](https://user-images.githubusercontent.com/92044428/150626427-15aa7a4b-9c83-46cb-95fd-1160f8ad9511.png)

=After=
![image](https://user-images.githubusercontent.com/92044428/150626739-3fc3637b-624e-4113-92e0-25cdfe78fc25.png)

![image](https://user-images.githubusercontent.com/92044428/150626768-c4c9cbc8-c94a-4203-891e-c8c024cf584e.png)

