### PR TITLE
Add Google analytics

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -243,6 +243,9 @@ module.exports = configure(function (ctx) {
         // do something with the Electron main process Webpack cfg
         // extendWebpackPreload also available besides this chainWebpackPreload
       },
-    }
-  }
+    },
+    htmlVariables: {
+      analyticsId: ctx.dev ? 'G-GBPD0EVWBJ' : 'G-RKKEVC5VJY',
+    },
+  };
 });

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -73,6 +73,15 @@
     />
     <meta name="msapplication-TileColor" content="#ffffff" />
     <meta name="theme-color" content="#ffffff" />
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= analyticsId %>"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', '<%= analyticsId %>');
+    </script>
   </head>
   <body>
     <!-- DO NOT touch the following DIV -->


### PR DESCRIPTION
**Pull Request Summary**

> This PR adds Google Analytics to the portal
Two GA profiles are created, one for development and another one for production

![image](https://user-images.githubusercontent.com/8452361/151005148-ed594139-f3e5-47ee-b517-b12100e0e663.png)

**Check list**
- [ ] contains breaking changes
- [x] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- Google analytice