### PR TITLE
Dapp video url fix

### DIFF
--- a/src/components/dapp-staking/modals/RegisterDappMedia.vue
+++ b/src/components/dapp-staking/modals/RegisterDappMedia.vue
@@ -124,7 +124,7 @@ export default defineComponent({
     const getEmbedUrl = (url: string): string | null => {
       const id = getVideoId(url);
 
-      return 'http://www.youtube.com/embed/' + id;
+      return 'https://www.youtube.com/embed/' + id;
     };
 
     const videoUrlChanged = (url: string): void => {


### PR DESCRIPTION
**Pull Request Summary**
Sometimes it happens that video is not displayed in dapp details dialog. I believe the main reason for that is we are accessing the portal over https and then trying to access video over http. 

![image](https://user-images.githubusercontent.com/8452361/153365521-72e7df56-1a6d-4eed-b1f2-69945b276d88.png)

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Fixes**
- dapp info video url

**To-dos**
> update firebase videos url to use ssl
