### PR TITLE
fix: styling in vesting info modal for mobile screen size

### DIFF
--- a/src/components/balance/modals/ModalVestingInfo.vue
+++ b/src/components/balance/modals/ModalVestingInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <Modal title="Vesting info" @click="closeModal">
     <template #content>
-      <div class="tw-w-96">
+      <div class="md:tw-w-96">
         <div class="tw-flex tw-space-x-2 tw-text-xl">
           <b><format-balance :balance="accountData.vestedClaimable" /></b>
           <span>{{ $t('balance.modals.availableToUnlock') }}</span>


### PR DESCRIPTION
**Pull Request Summary**

* fixed styling in vesting info modal for mobile screen size
(FYI @bobo-k2 )

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Fixes**
Before:
![image](https://user-images.githubusercontent.com/92044428/154610974-686da174-9e65-41ec-b457-562d2827a556.png)

After:
<img width="508" alt="image" src="https://user-images.githubusercontent.com/92044428/154611102-9f8ec797-6d32-4ad3-8478-ed4216d7df18.png">
