### PR TITLE
feat: added 'transfer to my address' checkbox

### DIFF
--- a/src/components/balance/PlmBalance.vue
+++ b/src/components/balance/PlmBalance.vue
@@ -58,7 +58,7 @@
               tw-flex-wrap tw-justify-center
             "
           >
-            <button
+            <Button
               type="button"
               :disabled="!address"
               class="transfer-button small-button"
@@ -66,7 +66,7 @@
               @click="openTransferModal"
             >
               {{ $t('balance.transfer') }}
-            </button>
+            </Button>
             <Button
               class="transfer-button"
               :class="isEvmDeposit ? 'large-button' : 'small-button'"
@@ -74,17 +74,17 @@
             >
               {{ $t('balance.vestingInfo') }}
             </Button>
-            <button type="button" class="transfer-button small-button" @click="openFaucetModal">
+            <Button type="button" class="transfer-button small-button" @click="openFaucetModal">
               {{ $t('balance.faucet') }}
-            </button>
-            <button
+            </Button>
+            <Button
               v-if="isEvmDeposit && !isH160"
               type="button"
               class="transfer-button"
               @click="openWithdrawalModal"
             >
               {{ $t('balance.withdrawEvm') }}
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -180,7 +180,7 @@
         </div>
       </div>
 
-      <div
+      <Button
         v-if="isEthWallet"
         class="
           tw-flex tw-justify-center tw-items-center tw-mb-0 tw-py-3 tw-px-2
@@ -194,11 +194,13 @@
         <div>
           <p class="tw-font-bold tw-text-right">
             <span class="tw-leading-tight tw-text-xs tw-text-white">{{
-              $t('balance.switchToLockdrop', { value: isH160 ? 'Lockdrop' : 'EVM' })
+              $t('balance.switchToLockdrop', {
+                value: isH160 ? (isShibuya ? 'Native' : 'Lockdrop') : 'EVM',
+              })
             }}</span>
           </p>
         </div>
-      </div>
+      </Button>
     </div>
     <ModalVestingInfo
       v-if="showVestingModal"
@@ -224,6 +226,7 @@ import { getInjector } from 'src/hooks/helper/wallet';
 import Logo from '../common/Logo.vue';
 import { hasExtrinsicFailedEvent } from 'src/store/dapp-staking/actions';
 import { fasInfoCircle } from '@quasar/extras/fontawesome-v5';
+import { endpointKey, getProviderIndex } from 'src/config/chainEndpoints';
 
 export default defineComponent({
   components: {
@@ -253,6 +256,12 @@ export default defineComponent({
     const isH160 = computed(() => store.getters['general/isH160Formatted']);
     const selectedAddress = computed(() => store.getters['general/selectedAddress']);
     const substrateAccounts = computed(() => store.getters['general/substrateAccounts']);
+    const isShibuya = computed(() => {
+      const chainInfo = store.getters['general/chainInfo'];
+      const chain = chainInfo ? chainInfo.chain : '';
+      const netowrkIdx = getProviderIndex(chain);
+      return netowrkIdx === endpointKey.SHIBUYA;
+    });
     const showVestingModal = ref<boolean>(false);
 
     const openTransferModal = (): void => {
@@ -389,6 +398,7 @@ export default defineComponent({
       showVestingInfo,
       fasInfoCircle,
       hexToString,
+      isShibuya,
       ...toRefs(props),
     };
   },

--- a/src/components/balance/modals/MetamaskOption.vue
+++ b/src/components/balance/modals/MetamaskOption.vue
@@ -59,13 +59,12 @@
   </div>
 </template>
 <script lang="ts">
-import { defineComponent, computed, ref, watchEffect } from 'vue';
-import { useStore } from 'src/store';
+import { useMetamask } from 'src/hooks/custom-signature/useMetamask';
 import * as utils from 'src/hooks/custom-signature/utils';
 import { getShortenAddress } from 'src/hooks/helper/addressUtils';
 import { EcdsaAddressFormat } from 'src/hooks/types/CustomSignature';
-import { useMetamask } from 'src/hooks/custom-signature/useMetamask';
-import { ASTAR_SS58_FORMAT } from 'src/hooks/helper/plasmUtils';
+import { useStore } from 'src/store';
+import { computed, defineComponent, ref, watchEffect } from 'vue';
 
 export default defineComponent({
   components: {},
@@ -108,21 +107,7 @@ export default defineComponent({
       try {
         const accounts = await requestAccounts();
         const loadingAddr = accounts[0];
-        const loginMsg = `Sign this message to login with address ${loadingAddr}`;
-
-        const signature = await requestSignature(loginMsg, loadingAddr);
-        console.log(signature);
-
-        if (typeof signature !== 'string') {
-          throw new Error('Failed to fetch signature');
-        }
-
-        // FIXME: keccak issue should be resolved : https://github.com/cryptocoinjs/keccak/pull/22
-        const pubKey = utils.recoverPublicKeyFromSig(loadingAddr, loginMsg, signature);
-
-        console.log(`Public key: ${pubKey}`);
-
-        const ss58Address = utils.ecdsaPubKeyToSs58(pubKey, ASTAR_SS58_FORMAT);
+        const ss58Address = await utils.ethWalletToSs58Address(loadingAddr, requestSignature);
 
         console.log(`ethereum: ${loadingAddr} / ss58: ${ss58Address}`);
 

--- a/src/components/balance/modals/ModalSelectAccount.vue
+++ b/src/components/balance/modals/ModalSelectAccount.vue
@@ -186,7 +186,7 @@ export default defineComponent({
       if (props.role === Role.FromAddress) {
         valueAddressOrWallet.value = currentAccountName.value;
       } else {
-        // Memo: `props.toAddress` is defined whenever user clicked 'transfer to own address' checkbox
+        // Memo: `props.toAddress` is defined whenever user clicked 'transfer to my address' checkbox
         const destAddress = props.toAddress ?? selAddress.value;
         valueAddressOrWallet.value = destAddress;
       }

--- a/src/components/balance/modals/ModalSelectAccount.vue
+++ b/src/components/balance/modals/ModalSelectAccount.vue
@@ -135,10 +135,11 @@ export default defineComponent({
 
     const isH160 = computed(() => store.getters['general/isH160Formatted']);
     const isEthWallet = computed(() => store.getters['general/isEthWallet']);
-    const selAccountIdx = props.role === Role.ToAddress ? ref('') : ref(currentAddress.value);
+    const selAccountIdx = ref<string>(props.role === Role.ToAddress ? '' : currentAddress.value);
     const account = getSelectedAccount(substrateAccounts.value);
 
     const selAddress = ref(!isH160 ? (account?.address as string) : '');
+    const valueAddressOrWallet = ref<string>('');
 
     watch(
       [selAccountIdx, isEthWallet],
@@ -181,10 +182,14 @@ export default defineComponent({
       }, 400);
     };
 
-    const valueAddressOrWallet = ref<string>('');
     watchEffect(() => {
-      valueAddressOrWallet.value =
-        props.role === Role.FromAddress ? String(currentAccountName.value) : selAddress.value;
+      if (props.role === Role.FromAddress) {
+        valueAddressOrWallet.value = currentAccountName.value;
+      } else {
+        // Memo: `props.toAddress` is defined whenever user clicked 'transfer to own address' checkbox
+        const destAddress = props.toAddress ?? selAddress.value;
+        valueAddressOrWallet.value = destAddress;
+      }
     });
 
     const changeAddress = (e: any) => {

--- a/src/components/common/Button.vue
+++ b/src/components/common/Button.vue
@@ -51,7 +51,7 @@ export default defineComponent({
 
 <style scoped>
 .dark-bg-blue:hover {
-  @apply dark:tw-bg-blue-400;
+  @apply tw-bg-blue-700 dark:tw-bg-blue-400;
 }
 .dark-ring-blue:focus {
   @apply dark:tw-ring-blue-400;

--- a/src/hooks/custom-signature/utils.ts
+++ b/src/hooks/custom-signature/utils.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as ethUtils from 'ethereumjs-util';
-// import * as ethUtils from './ethereumjs-util';
 import { publicKeyConvert } from 'secp256k1';
 
-import { hexAddPrefix, hexToU8a, isHex, u8aToHex } from '@polkadot/util';
+import { hexToU8a, isHex, u8aToHex } from '@polkadot/util';
 import { blake2AsU8a, encodeAddress, isEthereumAddress } from '@polkadot/util-crypto';
+import { ASTAR_SS58_FORMAT } from './../helper/plasmUtils';
 
 /**
  * Converts ECDSA public key into a valid ss58 address for Substrate.
@@ -75,4 +75,18 @@ export const recoverPublicKeyFromSig = (
   const compressedKey = publicKeyConvert(Buffer.from(prefixedPubKey, 'hex'), true);
 
   return u8aToHex(compressedKey);
+};
+
+export const ethWalletToSs58Address = async (
+  ethAddress: string,
+  requestSignature: (msg: string, ethAddress: string) => Promise<string>
+): Promise<string> => {
+  const msg = `Sign this message to login with address ${ethAddress}`;
+  const signature = await requestSignature(msg, ethAddress);
+  if (typeof signature !== 'string') {
+    throw new Error('Failed to fetch signature');
+  }
+
+  const pubKey = recoverPublicKeyFromSig(ethAddress, msg, signature);
+  return ecdsaPubKeyToSs58(pubKey, ASTAR_SS58_FORMAT);
 };

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -83,10 +83,7 @@ export const useConnectWallet = () => {
   const toggleMetaMaskSchema = async () => {
     const accounts = await requestAccounts();
     const loadingAddr = accounts[0];
-    const loginMsg = `Sign this message to login with address ${loadingAddr}`;
-    const signature = await requestSignature(loginMsg, loadingAddr);
-    const pubKey = utils.recoverPublicKeyFromSig(loadingAddr, loginMsg, signature);
-    const ss58Address = utils.ecdsaPubKeyToSs58(pubKey, ASTAR_SS58_FORMAT);
+    const ss58Address = await utils.ethWalletToSs58Address(loadingAddr, requestSignature);
 
     if (isH160.value) {
       store.commit('general/setIsH160Formatted', false);

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -102,6 +102,7 @@ export default {
       destBalance: 'Balance:',
       evmModeWarning: 'You are in EVM mode. Do not send funds to exchanges!',
       notSendToExchanges: 'I’m not sending tokens to Exchanges',
+      transferToMyOwn: 'I want to transfer to my {network} account',
     },
   },
   contracts: {


### PR DESCRIPTION
**Pull Request Summary**

* Changed in Shibuya testnet only
  * Switch to Lockdrop account -> Switch to Native account
  * Added transfer to my Native/EVM account checkbox whenever user login from Ethereum wallet

* Refactoring logic around getting the SS58 address from Ethereum wallet via custom signature
* Unify the hover styling in Button components

**Check list**
- [ ] contains breaking changes
- [x] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
![image](https://user-images.githubusercontent.com/92044428/155297561-c58b1baf-1741-4bd4-af4c-64d79382f3ea.png)

**Changes**
![image](https://user-images.githubusercontent.com/92044428/155297384-47eb75d1-8370-4ddd-9e3b-350d53f744cf.png)
