### PR TITLE
fix: modal padding

### DIFF
--- a/src/components/header/modals/ModalAccount.vue
+++ b/src/components/header/modals/ModalAccount.vue
@@ -76,7 +76,7 @@
     </div>
   </astar-simple-modal>
 </template>
- <script lang="ts">
+<script lang="ts">
 import { defineComponent, ref, computed } from 'vue';
 import { providerEndpoints } from 'src/config/chainEndpoints';
 import { SupportWallet } from 'src/config/wallets';
@@ -177,7 +177,7 @@ export default defineComponent({
 });
 </script>
 
- <style lang="scss" scoped>
+<style lang="scss" scoped>
 @import 'src/css/quasar.variables.scss';
 
 .list--account {
@@ -189,8 +189,8 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding-top: 32px;
-  padding-bottom: 40px;
+  padding-top: 24px;
+  padding-bottom: 20px;
 }
 
 .class-radio {

--- a/src/components/header/modals/ModalAccount.vue
+++ b/src/components/header/modals/ModalAccount.vue
@@ -179,6 +179,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @import 'src/css/quasar.variables.scss';
+@import 'src/css/utils.scss';
 
 .list--account {
   max-height: 460px;
@@ -198,7 +199,7 @@ export default defineComponent({
   align-items: center;
   background: #fff;
   border-radius: 6px;
-  width: 19.688rem;
+  width: rem(314);
   font-weight: 700;
   font-size: 16px;
   line-height: 18px;

--- a/src/components/header/modals/ModalConnectWallet.vue
+++ b/src/components/header/modals/ModalConnectWallet.vue
@@ -10,7 +10,7 @@
         @click="setWalletModal(wallet.source)"
       >
         <div class="box--img">
-          <img width="40" :src="wallet.img" />
+          <img :src="wallet.img" />
         </div>
         <div>{{ wallet.name }}</div>
       </div>
@@ -24,7 +24,7 @@
         @click="setWalletModal(wallet.source)"
       >
         <div class="box--img">
-          <img width="40" :src="wallet.img" />
+          <img :src="wallet.img" />
         </div>
         <div>{{ wallet.name }}</div>
       </div>
@@ -126,6 +126,7 @@ export default defineComponent({
   margin: 0 auto;
   margin-top: 16px;
   padding: 16px;
+  padding-left: 24px;
   cursor: pointer;
 
   &:hover {
@@ -137,8 +138,8 @@ export default defineComponent({
   }
 
   .box--img {
-    width: 40px;
-    height: 40px;
+    width: 24px;
+    height: 24px;
     margin-right: 13px;
   }
 }

--- a/src/components/header/modals/ModalConnectWallet.vue
+++ b/src/components/header/modals/ModalConnectWallet.vue
@@ -1,6 +1,6 @@
 <template>
   <astar-simple-modal :show="isModalConnectWallet" title="Select a Wallet" @close="setCloseModal">
-    <div class="wrapper--modal">
+    <div class="wrapper--modal--wallet">
       <div class="title--account-type">{{ $t('wallet.nativeAccount') }}</div>
       <div
         v-for="(wallet, index) in nativeWallets"
@@ -94,12 +94,12 @@ export default defineComponent({
 <style lang="scss" scoped>
 @import 'src/css/quasar.variables.scss';
 
-.wrapper--modal {
+.wrapper--modal--wallet {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding-top: 32px;
-  padding-bottom: 40px;
+  padding-top: 24px;
+  padding-bottom: 20px;
 }
 
 .title--account-type {

--- a/src/components/header/modals/ModalConnectWallet.vue
+++ b/src/components/header/modals/ModalConnectWallet.vue
@@ -93,6 +93,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @import 'src/css/quasar.variables.scss';
+@import 'src/css/utils.scss';
 
 .wrapper--modal--wallet {
   display: flex;
@@ -116,8 +117,8 @@ export default defineComponent({
   align-items: center;
   background: #fff;
   border-radius: 6px;
-  height: 3.5rem;
-  width: 19.688rem;
+  height: rem(56);
+  width: rem(314);
   font-weight: 700;
   font-size: 16px;
   line-height: 18px;

--- a/src/components/header/modals/ModalNetwork.vue
+++ b/src/components/header/modals/ModalNetwork.vue
@@ -68,7 +68,7 @@
     </div>
   </astar-simple-modal>
 </template>
- <script lang="ts">
+<script lang="ts">
 import { defineComponent, ref, computed } from 'vue';
 import { providerEndpoints, endpointKey } from 'src/config/chainEndpoints';
 import { useStore } from 'src/store';
@@ -139,6 +139,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @import 'src/css/quasar.variables.scss';
+@import 'src/css/utils.scss';
 
 .wrapper--modal-network {
   display: flex;
@@ -153,8 +154,8 @@ export default defineComponent({
   align-items: center;
   background: #fff;
   border-radius: 6px;
-  height: 3.5rem;
-  width: 19.688rem;
+  height: rem(56);
+  width: rem(314);
   font-weight: 700;
   font-size: 16px;
   line-height: 18px;

--- a/src/components/header/modals/SelectWallet.vue
+++ b/src/components/header/modals/SelectWallet.vue
@@ -112,14 +112,16 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @import 'src/css/quasar.variables.scss';
+@import 'src/css/utils.scss';
+
 .box__row--wallet {
   display: flex;
   justify-content: space-between;
   align-items: center;
   background: #fff;
   border-radius: 6px;
-  height: 3.5rem;
-  width: 19.688rem;
+  height: rem(56);
+  width: rem(314);
   font-weight: 700;
   font-size: 16px;
   line-height: 18px;
@@ -160,7 +162,7 @@ export default defineComponent({
 
 .box--wallet-option {
   position: absolute;
-  width: 19.688rem;
+  width: rem(314);
   margin-left: 20px;
   margin-top: 36px;
   border-radius: 6px;
@@ -174,7 +176,7 @@ export default defineComponent({
   border-radius: 6px;
   padding-top: 4px;
   overflow: auto;
-  width: 19.688rem;
+  width: rem(314);
   &:focus {
     outline: none;
   }

--- a/src/components/sidenav/SidebarDesktop.vue
+++ b/src/components/sidenav/SidebarDesktop.vue
@@ -137,6 +137,7 @@ export default defineComponent({
 </script>
 <style lang="scss" scoped>
 @import 'src/css/quasar.variables.scss';
+@import 'src/css/utils.scss';
 
 .icon {
   text-align: center;
@@ -161,13 +162,13 @@ export default defineComponent({
 }
 
 .menu {
-  margin-top: 2rem;
+  margin-top: rem(32);
   margin-left: 24px;
   flex-grow: 1;
 
   .row--item {
     flex: 1 1 0%;
-    margin-left: 0.75rem;
+    margin-left: rem(12);
   }
 }
 
@@ -193,13 +194,13 @@ export default defineComponent({
 
 .wrapper--bottom {
   flex-shrink: 0;
-  padding: 1rem;
+  padding: rem(16);
 
   .wrapper--option {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding-top: 0.3rem;
+    padding-top: rem(4.8);
   }
 }
 

--- a/src/components/sidenav/SidebarMobile.vue
+++ b/src/components/sidenav/SidebarMobile.vue
@@ -81,6 +81,7 @@ export default defineComponent({
 </script>
 <style lang="scss" scoped>
 @import 'src/css/quasar.variables.scss';
+@import 'src/css/utils.scss';
 
 .header {
   overflow: hidden;
@@ -132,13 +133,13 @@ export default defineComponent({
   color: $gray-3;
   border-radius: 16px;
   margin-top: 4px;
-  margin-right: 1rem;
+  margin-right: rem(16);
   padding-left: 4px;
 }
 
 .wrapper--bottom {
   flex-shrink: 0;
-  padding: 1rem;
+  padding: rem(16);
   background: $gray-1;
   color: $gray-4;
   box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.1);
@@ -150,9 +151,9 @@ export default defineComponent({
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    padding-left: 1.8rem;
-    padding-right: 1.8rem;
-    padding-top: 0.3rem;
+    padding-left: rem(28.8);
+    padding-right: rem(28.8);
+    padding-top: rem(4.8);
   }
 }
 

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -9,6 +9,7 @@
 @use 'src/css/modal.scss';
 @use 'src/css/box.scss';
 @use 'src/css/astar-ui.scss';
+@use 'src/css/utils.scss';
 
 body {
   background: $body-bg-light;

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -9,7 +9,6 @@
 @use 'src/css/modal.scss';
 @use 'src/css/box.scss';
 @use 'src/css/astar-ui.scss';
-@use 'src/css/utils.scss';
 
 body {
   background: $body-bg-light;

--- a/src/css/astar-ui.scss
+++ b/src/css/astar-ui.scss
@@ -35,10 +35,7 @@
       display: flex;
       justify-content: center;
       color: $gray-5 !important;
-
-      margin-top: 28px;
-      // margin-bottom: -24px;
-      margin-left: 44px;
+      margin-top: -22px;
     }
   }
 }

--- a/src/css/astar-ui.scss
+++ b/src/css/astar-ui.scss
@@ -35,6 +35,10 @@
       display: flex;
       justify-content: center;
       color: $gray-5 !important;
+
+      margin-top: 28px;
+      // margin-bottom: -24px;
+      margin-left: 44px;
     }
   }
 }

--- a/src/css/modal.scss
+++ b/src/css/modal.scss
@@ -2,7 +2,7 @@
 
 .wrapper--modal {
   padding: 46px 4px;
-  padding-bottom: 24px;
+  padding-bottom: 20px;
 }
 
 .body--dark {

--- a/src/css/utils.scss
+++ b/src/css/utils.scss
@@ -1,0 +1,3 @@
+@function rem($px) {
+  @return ($px / 16) * 1rem;
+}


### PR DESCRIPTION
**Pull Request Summary**

* Padding of the "Select a wallet" and "Wallet" modal 
  * ref: https://github.com/AstarNetwork/astar-apps/pull/297#issuecomment-1081887070
* Size of the wallet logo
* Padding-left of the wallet row 
* Adjusted modal title (y direction) 
* Converted px to rem by scss function

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

=Before=

![image](https://user-images.githubusercontent.com/92044428/160751898-bae79d79-c16a-47f0-839f-fcb43a43dcce.png)

=After=
![image](https://user-images.githubusercontent.com/92044428/160753125-4426bdfb-067e-418d-ad97-c3f68c07432a.png)

![image](https://user-images.githubusercontent.com/92044428/160753345-08365f9d-d760-49ae-89ec-ac9b7c153e58.png)

![image](https://user-images.githubusercontent.com/92044428/160753480-3438d451-8696-4175-a2a3-85f3af7f1e4a.png)
