### PR TITLE
fix: change account

### DIFF
--- a/src/components/header/Header.vue
+++ b/src/components/header/Header.vue
@@ -11,7 +11,7 @@
         <ConnectButton @click="openSelectModal" />
       </template>
       <template v-else>
-        <AccountButton :account="currentAccount" @click="disconnectAccount" />
+        <AccountButton :account="currentAccount" @click="changeAccount" />
       </template>
       <NetworkButton @show-network="modalNetwork = true" />
     </astar-header>
@@ -90,7 +90,7 @@ export default defineComponent({
       setCloseModal,
       setWalletModal,
       openSelectModal,
-      disconnectAccount,
+      changeAccount,
     } = useConnectWallet();
 
     if (!currentAccount.value) {
@@ -131,12 +131,12 @@ export default defineComponent({
       currentAccountName,
       selectedWallet,
       modalAccountSelect,
+      width,
+      screenSize,
       setCloseModal,
       setWalletModal,
       openSelectModal,
-      disconnectAccount,
-      width,
-      screenSize,
+      changeAccount,
     };
   },
 });

--- a/src/components/header/Header.vue
+++ b/src/components/header/Header.vue
@@ -93,10 +93,6 @@ export default defineComponent({
       changeAccount,
     } = useConnectWallet();
 
-    if (!currentAccount.value) {
-      openSelectModal();
-    }
-
     const store = useStore();
     const currentNetworkIdx = computed(() => store.getters['general/networkIdx']);
     const route = useRoute();

--- a/src/components/header/modals/ModalAccount.vue
+++ b/src/components/header/modals/ModalAccount.vue
@@ -77,7 +77,11 @@
         </fieldset>
       </div>
       <div class="wrapper__row--button">
-        <button :disabled="!selAccount" class="btn btn--connect" @click="selectAccount(selAccount)">
+        <button
+          :disabled="substrateAccounts.length > 0 && !selAccount"
+          class="btn btn--connect"
+          @click="selectAccount(selAccount)"
+        >
           {{ $t('connect') }}
         </button>
       </div>
@@ -140,7 +144,7 @@ export default defineComponent({
     const isSupportContract = ref(providerEndpoints[currentNetworkIdx.value].isSupportContract);
 
     const selectAccount = (account: string) => {
-      store.commit('general/setCurrentAddress', account);
+      account && store.commit('general/setCurrentAddress', account);
       emit('update:is-open', false);
     };
 

--- a/src/components/header/modals/ModalAccount.vue
+++ b/src/components/header/modals/ModalAccount.vue
@@ -85,15 +85,15 @@
   </astar-simple-modal>
 </template>
 <script lang="ts">
-import { defineComponent, ref, computed } from 'vue';
+import SelectWallet from 'src/components/header/modals/SelectWallet.vue';
 import { providerEndpoints } from 'src/config/chainEndpoints';
 import { SupportWallet } from 'src/config/wallets';
 import { useAccount } from 'src/hooks';
 import { castMobileSource } from 'src/hooks/helper/wallet';
 import { useStore } from 'src/store';
 import { SubstrateAccount } from 'src/store/general/state';
+import { computed, defineComponent, ref } from 'vue';
 import { useRouter } from 'vue-router';
-import SelectWallet from 'src/components/header/modals/SelectWallet.vue';
 
 export default defineComponent({
   components: {
@@ -144,9 +144,7 @@ export default defineComponent({
       emit('update:is-open', false);
     };
 
-    const selAccount = ref<string>(
-      substrateAccounts.value.length > 0 ? substrateAccounts.value[0].address : ''
-    );
+    const selAccount = ref<string>('');
 
     const currentNetworkStatus = computed(() => store.getters['general/networkStatus']);
 

--- a/src/components/header/modals/ModalAccount.vue
+++ b/src/components/header/modals/ModalAccount.vue
@@ -77,7 +77,7 @@
         </fieldset>
       </div>
       <div class="wrapper__row--button">
-        <button class="btn btn--connect" @click="selectAccount(selAccount)">
+        <button :disabled="!selAccount" class="btn btn--connect" @click="selectAccount(selAccount)">
           {{ $t('connect') }}
         </button>
       </div>

--- a/src/components/header/modals/SelectWallet.vue
+++ b/src/components/header/modals/SelectWallet.vue
@@ -29,15 +29,9 @@
   </div>
 </template>
 <script lang="ts">
-import {
-  supportAllWallets,
-  supportAllWalletsObj,
-  SupportWallet,
-  supportWalletObj,
-  Wallet,
-} from 'src/config/wallets';
+import { supportAllWallets, supportAllWalletsObj, SupportWallet, Wallet } from 'src/config/wallets';
 import { isMobileDevice } from 'src/hooks/helper/wallet';
-import { defineComponent, ref, watch, watchEffect, PropType, computed } from 'vue';
+import { computed, defineComponent, PropType, ref, watch, watchEffect } from 'vue';
 import SelectWalletOption from './SelectWalletOption.vue';
 
 export default defineComponent({

--- a/src/components/header/modals/SelectWalletOption.vue
+++ b/src/components/header/modals/SelectWalletOption.vue
@@ -11,7 +11,7 @@
   </li>
 </template>
 <script lang="ts">
-import { defineComponent, toRefs, computed } from 'vue';
+import { defineComponent } from 'vue';
 export default defineComponent({
   props: {
     iconWallet: {

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -21,7 +21,6 @@ export const useAccount = () => {
       ss58: '',
       h160: '',
     });
-    localStorage.removeItem(SELECTED_ADDRESS);
   };
 
   const currentAccount = ref<string>('');

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -23,7 +23,11 @@ function useCall(addressRef: Ref<string>) {
 
   const updateAccountH160 = async (address: string) => {
     try {
-      const rawBal = await getBalance($web3.value!!, address);
+      const web3Ref = $web3.value;
+      if (!web3Ref || !web3Ref.utils.checkAddressChecksum(address)) {
+        return;
+      }
+      const rawBal = await getBalance(web3Ref, address);
       accountDataRef.value = new AccountDataH160(
         new BN(rawBal),
         new BN(0),

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -15,6 +15,7 @@ import {
   checkIsWalletExtension,
   getDeepLinkUrl,
   getInjectedExtensions,
+  getSelectedAccount,
   isMobileDevice,
 } from './helper/wallet';
 
@@ -43,6 +44,16 @@ export const useConnectWallet = () => {
 
   const { SELECTED_ADDRESS } = LOCAL_STORAGE;
 
+  const selectedWalletSource = computed(() => {
+    try {
+      const accounts = store.getters['general/substrateAccounts'];
+      const selectedAccount = getSelectedAccount(accounts);
+      return selectedAccount ? selectedAccount.source : null;
+    } catch (error) {
+      return null;
+    }
+  });
+
   const setCloseModal = () => {
     modalName.value = '';
   };
@@ -50,6 +61,14 @@ export const useConnectWallet = () => {
   const openSelectModal = () => {
     modalName.value = WalletModalOption.SelectWallet;
   };
+
+  watchEffect(() => {
+    if (!selectedWalletSource.value) {
+      openSelectModal();
+    } else {
+      selectedWallet.value = selectedWalletSource.value;
+    }
+  });
 
   const loadMetaMask = async (ss58?: string): Promise<boolean> => {
     try {

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -136,6 +136,16 @@ export const useConnectWallet = () => {
     setWallet(wallet);
   };
 
+  const changeAccount = async () => {
+    const chosenWallet = selectedWallet.value;
+    disconnectAccount();
+    if (chosenWallet === SupportWallet.MetaMask) {
+      openSelectModal();
+    } else {
+      await setWalletModal(chosenWallet as SupportWallet);
+    }
+  };
+
   watchEffect(async () => {
     const lookupWallet = castMobileSource(modalName.value);
     if (SubstrateWallets.find((it) => it === lookupWallet)) {
@@ -204,5 +214,6 @@ export const useConnectWallet = () => {
     setWalletModal,
     disconnectAccount,
     toggleMetaMaskSchema,
+    changeAccount,
   };
 };


### PR DESCRIPTION
**Pull Request Summary**

* Change the account rather than disconnect the wallet
  * Ref: https://github.com/AstarNetwork/astar-apps/pull/297#issuecomment-1081390410
      > The current behaviour on the staging is - when you want to switch the wallet and click the header button you'll get disconnected but I would like to fix. The whole idea is to be able to feel to switch without disconnecting. To be able to this so, we need the wallet select area in the design (1) Can we do this?

* Enable `Connect` button whenever users have selected account
* Remember selected wallet account via local storage

=Before=
https://gyazo.com/6c0481ea04826de4f62aa089bff54317

![image](https://user-images.githubusercontent.com/92044428/160836253-c28f3d81-2c7d-4d56-916a-173ce70e9a79.png)

=After=
https://gyazo.com/f58cceb4fca2cda94d692115aed884a8

![image](https://user-images.githubusercontent.com/92044428/160836320-a42de3d4-1674-469e-a5a7-bc28852b96b5.png)


**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

