### PR TITLE
fix: updata metadata

### DIFF
--- a/src/components/header/MetaUpdateButton.vue
+++ b/src/components/header/MetaUpdateButton.vue
@@ -35,24 +35,24 @@ export default defineComponent({
     const metaExtensions = computed(() => store.getters['general/metaExtensions']);
     const extensionCount = computed(() => store.getters['general/extensionCount']);
 
-    const selectedIndex = 0;
-    const isBusy = ref(false);
-    const isComplete = ref(false);
+    const isBusy = ref<boolean>(false);
+    const isComplete = ref<boolean>(false);
     const updateMetadata = () => {
       const extensions = metaExtensions?.value?.extensions;
-
-      if (chainInfo.value && extensions?.[selectedIndex]) {
-        isBusy.value = true;
-
-        extensions[selectedIndex]
-          .update(JSON.parse(JSON.stringify(chainInfo.value)))
-          .then(() => {
-            isBusy.value = false;
-            isComplete.value = true;
-            emit('updated-meta');
-          })
-          .catch(console.error);
-      }
+      extensions.forEach((extension: any) => {
+        if (chainInfo.value && extension) {
+          isBusy.value = true;
+          isComplete.value = false;
+          extension
+            .update(JSON.parse(JSON.stringify(chainInfo.value)))
+            .then(() => {
+              isBusy.value = false;
+              isComplete.value = true;
+              emit('updated-meta');
+            })
+            .catch(console.error);
+        }
+      });
     };
     return {
       width,

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -24,7 +24,7 @@ function useCall(addressRef: Ref<string>) {
   const updateAccountH160 = async (address: string) => {
     try {
       const web3Ref = $web3.value;
-      if (!web3Ref || !web3Ref.utils.checkAddressChecksum(address)) {
+      if (!web3Ref || !web3Ref.utils.isAddress(address)) {
         return;
       }
       const rawBal = await getBalance(web3Ref, address);

--- a/src/hooks/useMetaExtensions.ts
+++ b/src/hooks/useMetaExtensions.ts
@@ -72,14 +72,13 @@ function hasCurrentProperties(api: ApiPromise, { extension }: ExtensionKnown): b
 function filterAll(api: ApiPromise, all: ExtensionKnown[]): Extensions {
   const extensions = all
     .map((info): ExtensionInfo | null => {
+      // Memo: Talisman and Mathwallet return null
       const current = info.known.find(({ genesisHash }) => api.genesisHash.eq(genesisHash)) || null;
+      const isUpgradable =
+        (current && api.runtimeVersion.specVersion.gtn(current.specVersion)) ||
+        !hasCurrentProperties(api, info);
 
-      // if we cannot find it as known, or either the specVersion or properties mismatches, mark it as upgradable
-      return !current ||
-        api.runtimeVersion.specVersion.gtn(current.specVersion) ||
-        !hasCurrentProperties(api, info)
-        ? { ...info, current }
-        : null;
+      return isUpgradable ? { ...info, current } : null;
     })
     .filter((info): info is ExtensionInfo => !!info);
 


### PR DESCRIPTION
**Pull Request Summary**

Display the `Upgrade Metadata` button for wallets that are upgradable only. Ignore wallets (such as talisman and mathwallet) that don't have version data. Otherwise the portal displays the `Upgrade Metadata` button whenever the app is launched.

=Before=
https://www.loom.com/share/77f04c7232bf482291da4889949ca5fb

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

