### PR TITLE
fix: disable transfer button whenever EVM wallet connects to the wrong network

### DIFF
--- a/src/components/assets/modals/ModalSelectAccount.vue
+++ b/src/components/assets/modals/ModalSelectAccount.vue
@@ -20,6 +20,7 @@
           class="input--address text--title"
           type="text"
           spellcheck="false"
+          placeholder="Destination Address"
           @focus="openOption = !isEthWallet"
           @blur="closeOption"
           @change="changeAddress"

--- a/src/components/assets/modals/ModalTransfer.vue
+++ b/src/components/assets/modals/ModalTransfer.vue
@@ -64,7 +64,7 @@
           </div>
         </div>
 
-        <div v-if="isChosenWrongEvmNetwork" class="rows__row--wrong-evm">
+        <div v-if="isChoseWrongEvmNetwork" class="rows__row--wrong-evm">
           <span class="text--error">{{ $t('assets.wrongNetwork') }}</span>
           <span class="text--connect-rpc" @click="connectEvmNetwork">
             {{ $t('assets.connectNetwork', { network: currentNetworkName }) }}
@@ -185,12 +185,12 @@ export default defineComponent({
       return Number(providerEndpoints[networkIdx].evmChainId);
     });
 
-    const isChosenWrongEvmNetwork = computed(() => isH160.value && !isConnectedNetwork.value);
+    const isChoseWrongEvmNetwork = computed(() => isH160.value && !isConnectedNetwork.value);
 
     const isDisabledTransfer = computed(() => {
       const isLessAmount = 0 >= Number(transferAmt.value);
       const isMissedCheck = isRequiredCheck.value && !isChecked.value;
-      return errMsg.value !== '' || isLessAmount || isMissedCheck || isChosenWrongEvmNetwork.value;
+      return errMsg.value !== '' || isLessAmount || isMissedCheck || isChoseWrongEvmNetwork.value;
     });
 
     const inputHandler = (event: any): void => {
@@ -405,7 +405,7 @@ export default defineComponent({
       isRequiredCheck,
       tokenImg,
       isDisabledTransfer,
-      isChosenWrongEvmNetwork,
+      isChoseWrongEvmNetwork,
       currentNetworkName,
       connectEvmNetwork,
     };

--- a/src/components/assets/styles/modal-transfer.scss
+++ b/src/components/assets/styles/modal-transfer.scss
@@ -15,6 +15,13 @@
   justify-content: center;
 }
 
+.rows__row--wrong-evm {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: -18px;
+}
+
 .box--warning {
   display: grid;
   row-gap: 12px;
@@ -101,6 +108,13 @@
   }
 }
 
+.text--connect-rpc {
+  cursor: pointer;
+  color: $astar-blue;
+  text-decoration: underline;
+  font-weight: 600;
+}
+
 .input--amount {
   width: 180px;
   font-size: 22px;
@@ -169,5 +183,9 @@
 .body--dark {
   input {
     color: white;
+  }
+
+  .text--connect-rpc {
+    color: $astar-blue-dark;
   }
 }

--- a/src/config/web3/index.ts
+++ b/src/config/web3/index.ts
@@ -36,6 +36,7 @@ export enum EVM {
 
 export const chainName = {
   [EVM.ETHEREUM_MAINNET]: 'Ethereum Mainnet',
+  [EVM.ASTAR_MAINNET]: 'Astar Network Mainnet',
   [EVM.SHIDEN_MAINNET]: 'Shiden Network Mainnet',
   [EVM.SHIBUYA_TESTNET]: 'Shibuya Testnet',
   [EVM.BSC]: 'Binance Smart Chain',

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -25,3 +25,4 @@ export * from './c-bridge/useCbridgeV2';
 export * from './c-bridge/useCbridgeHistory';
 export * from './c-bridge/useCbridgeApproval';
 export * from './wallet/useWalletIcon';
+export * from './wallet/useEvmWallet';

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -72,16 +72,6 @@ export const useAccount = () => {
     { immediate: true }
   );
 
-  watchEffect(() => {
-    if (!currentEcdsaAccount.value.ethereum || !window.ethereum || !isH160Formatted.value) return;
-
-    window.ethereum.on('accountsChanged', (accounts: string[]) => {
-      if (accounts[0] !== currentAccount.value) {
-        disconnectAccount();
-      }
-    });
-  });
-
   return {
     substrateAccounts,
     currentAccount,

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -167,6 +167,22 @@ export const useConnectWallet = () => {
     }
   };
 
+  const changeEvmAccount = async () => {
+    if (!currentEcdsaAccount.value.ethereum || !window.ethereum || !isH160.value) {
+      return;
+    }
+    window.ethereum.on('accountsChanged', async (accounts: string[]) => {
+      if (accounts[0] !== currentAccount.value) {
+        disconnectAccount();
+        await setMetaMask();
+      }
+    });
+  };
+
+  watchEffect(async () => {
+    await changeEvmAccount();
+  });
+
   watchEffect(async () => {
     const lookupWallet = castMobileSource(modalName.value);
     if (SubstrateWallets.find((it) => it === lookupWallet)) {

--- a/src/hooks/wallet/useEvmWallet.ts
+++ b/src/hooks/wallet/useEvmWallet.ts
@@ -1,0 +1,64 @@
+import { getProviderIndex, providerEndpoints } from 'src/config/chainEndpoints';
+import { getEvmProvider } from 'src/hooks/helper/wallet';
+import { useStore } from 'src/store';
+import { computed, ref, watchEffect } from 'vue';
+import Web3 from 'web3';
+import { setupNetwork } from 'src/config/web3';
+
+export const useEvmWallet = () => {
+  const walletNetworkId = ref<number | null>(null);
+  const store = useStore();
+  const isH160 = computed(() => store.getters['general/isH160Formatted']);
+
+  const evmNetworkId = computed(() => {
+    const chainInfo = store.getters['general/chainInfo'];
+    const chain = chainInfo ? chainInfo.chain : '';
+    const networkId = getProviderIndex(chain);
+    return Number(providerEndpoints[networkId].evmChainId);
+  });
+
+  const isConnectedNetwork = computed(() => {
+    if (!isH160.value) return false;
+    return evmNetworkId.value === walletNetworkId.value;
+  });
+
+  const currentNetworkName = computed(() => {
+    const chainInfo = store.getters['general/chainInfo'];
+    const chain = chainInfo ? chainInfo.chain : '';
+    return chain === 'Shibuya Testnet' ? 'Shibuya' : chain;
+  });
+
+  const connectEvmNetwork = async () => {
+    try {
+      await setupNetwork(evmNetworkId.value);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  watchEffect(async () => {
+    try {
+      const provider = getEvmProvider();
+      if (!isH160.value || !provider) return;
+
+      const web3 = new Web3(provider as any);
+      const chainId = await web3.eth.getChainId();
+      walletNetworkId.value = chainId;
+
+      provider &&
+        provider.on('chainChanged', (chainId: string) => {
+          walletNetworkId.value = Number(chainId);
+        });
+    } catch (error) {
+      console.error(error);
+      walletNetworkId.value = null;
+    }
+  });
+
+  return {
+    isConnectedNetwork,
+    currentNetworkName,
+    evmNetworkId,
+    connectEvmNetwork,
+  };
+};

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -282,6 +282,8 @@ export default {
     noHash: 'Your transaction will not have a hash',
     addToWallet: 'Add to wallet',
     noResults: 'No results found :(',
+    wrongNetwork: 'Wallet connected to the wrong network',
+    connectNetwork: 'Connect to {network} RPC',
     modals: {
       max: 'Max',
       balance: 'Balance: {amount} {token}',


### PR DESCRIPTION
**Pull Request Summary**

* added placeholder to the destination address input
* disabled transfer button whenever EVM wallet connects to the wrong network
* refactored the function names for `watchEffect` in `useConnectWallet.ts`
* changed the connected account whenever users changed account in the EVM wallet
  * issue: https://github.com/AstarNetwork/astar-apps/issues/268
  * @bobo-k2 @hoonsubin I've fixed this issue in [this](https://github.com/AstarNetwork/astar-apps/pull/321/commits/62955afa29137082fac86403a7dc6448911d2e0b) commit while refactoring `useConnectWallet.ts`
  * Gif: https://gyazo.com/f639bcf4f70c57b72beafc0efeeb892e

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Changes**

![image](https://user-images.githubusercontent.com/92044428/161434265-c8161552-eeec-4d6d-b8f4-1525a5b93376.png)

Gif: https://gyazo.com/865f7dc905b9a652dbea83249b5a4753

![Screenshot 2022-04-03 at 9 11 47 PM](https://user-images.githubusercontent.com/92044428/161434176-2674f5c2-1dff-4d34-b3e2-376391643e25.png)
