### PR TITLE
fix: z-index bug in sidebar

### DIFF
--- a/src/components/sidenav/SidebarDesktop.vue
+++ b/src/components/sidenav/SidebarDesktop.vue
@@ -55,6 +55,7 @@
             <astar-text type="H4">{{ $t('common.staking') }}</astar-text>
           </div>
         </router-link>
+        <div v-else class="dummy-row" />
       </div>
       <div>
         <router-link
@@ -73,6 +74,7 @@
             <astar-text type="H4">{{ $t('bridge.bridge') }}</astar-text>
           </span>
         </router-link>
+        <div v-else class="dummy-row" />
       </div>
       <div class="menu__indicator" :class="getIndicatorClass(path)" />
     </nav>

--- a/src/components/sidenav/styles/sidebar-desktop.scss
+++ b/src/components/sidenav/styles/sidebar-desktop.scss
@@ -8,14 +8,17 @@
   width: 170px;
   margin-left: 8px;
 }
+
 .iconbase {
   color: $astar-blue-dark;
   width: 20px;
   height: 20px;
 }
+
 // .shiden {
 //   color: $shiden-purple-dark;
 // }
+
 .sidebar {
   width: 224px;
   height: 100%;
@@ -46,9 +49,9 @@
   margin-bottom: 8px;
   border-radius: 6px;
   color: $gray-5;
-  z-index: 1;
   position: relative;
 }
+
 .link:hover {
   background: linear-gradient(0deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05)), $object-light;
 }
@@ -69,9 +72,9 @@
   }
 }
 
+// Memo: set the animation indicator from the bottom of the menu
 .menu__indicator {
-  position: absolute;
-  background: #3c4649;
+  background: #d3d6dc;
   transition: all 0.3s ease 0s;
   border-radius: 6px;
   height: 38px;
@@ -79,21 +82,28 @@
 }
 
 .menu__assets {
-  top: 0;
+  margin-top: -183px;
 }
 
 .menu__dashboard {
-  top: 45px;
+  margin-top: -139px;
 }
 
 .menu__staking {
-  top: 92px;
+  margin-top: -92px;
 }
 .menu__bridge {
-  top: 136px;
+  margin-top: -46px;
+}
+
+.dummy-row {
+  height: 46px;
 }
 
 .body--dark {
+  .menu__indicator {
+    background: $gray-5-selected;
+  }
   .sidebar {
     background: $gray-5;
   }


### PR DESCRIPTION
**Pull Request Summary**

* Modified `z-index` in the sidebar (the sidebar class used `z-index` and `postion: absolute` to control the animated indicator, but it conflicted with the modal background)

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Fixes**

Before:
![image](https://user-images.githubusercontent.com/92044428/162577260-cf128e3c-69b5-46d2-b2fe-d24934ad59b5.png)


![image](https://user-images.githubusercontent.com/92044428/162568771-928397a3-216a-4edc-a94e-9142f1e621b3.png)

After:
![image](https://user-images.githubusercontent.com/92044428/162577640-9d63c768-7f12-42f4-a853-35eec4fe9941.png)


<img width="1353" alt="image" src="https://user-images.githubusercontent.com/92044428/162568814-5f8c2dfe-4ee4-4565-b20f-c1cb4ac8eaf1.png">

