### PR TITLE
Video url optional in dapp registration

### DIFF
--- a/src/components/dapp-staking/modals/ModalDappDetails.vue
+++ b/src/components/dapp-staking/modals/ModalDappDetails.vue
@@ -3,7 +3,7 @@
     <template #content>
       <div>
         <div class="tw-flex tw-flex-row tw-flex-wrap">
-          <q-card v-if="dapp.videoUrl" class="tw-w-96 md:tw-mr-4">
+          <q-card v-if="dapp.videoUrl || dapp.imagesUrl" class="tw-w-96 md:tw-mr-4">
             <q-carousel
               v-model:fullscreen="isFullScreen"
               v-model="slide"
@@ -14,7 +14,7 @@
               arrows
               infinite
             >
-              <q-carousel-slide v-model:fullscreen="isFullScreen" name="video">
+              <q-carousel-slide v-if="dapp.videoUrl" v-model:fullscreen="isFullScreen" name="video">
                 <q-video :src="dapp.videoUrl" name="video" class="absolute-full" />
               </q-carousel-slide>
               <q-carousel-slide
@@ -130,7 +130,7 @@ export default defineComponent({
   },
   emits: ['update:is-open', 'showStake'],
   setup(props, { emit }) {
-    const slide = ref<string>('video');
+    const slide = ref<string>(props.dapp.videoUrl ? 'video' : '0');
     const isFullScreen = ref<boolean>(false);
 
     const showStakeModal = (): void => {

--- a/src/components/dapp-staking/modals/RegisterDappMedia.vue
+++ b/src/components/dapp-staking/modals/RegisterDappMedia.vue
@@ -5,10 +5,7 @@
       outlined
       label="Youtube Video link"
       maxlength="500"
-      :rules="[
-        (v) => (v && v.length > 0) || 'dApp video link is required.',
-        (v) => getVideoId(v) !== null || 'Enter a valid YouTube url',
-      ]"
+      :rules="[(v) => getVideoId(v) !== null || 'Enter a valid YouTube url']"
       class="tw-my-2"
       @update:model-value="videoUrlChanged"
     >
@@ -115,16 +112,23 @@ export default defineComponent({
     };
 
     const getVideoId = (url: string): string | null => {
-      const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
-      const match = url.match(regExp);
+      if (url) {
+        const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
+        const match = url.match(regExp);
 
-      return match && match[2].length === 11 ? match[2] : null;
+        return match && match[2].length === 11 ? match[2] : null;
+      } else {
+        return '';
+      }
     };
 
     const getEmbedUrl = (url: string): string | null => {
-      const id = getVideoId(url);
-
-      return 'https://www.youtube.com/embed/' + id;
+      if (url) {
+        const id = getVideoId(url);
+        return 'https://www.youtube.com/embed/' + id;
+      } else {
+        return '';
+      }
     };
 
     const videoUrlChanged = (url: string): void => {


### PR DESCRIPTION
**Pull Request Summary**

Made videoUrl optional in dapp registration

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Changes**
- updated dapp registration form to allow empty video url
- updated dapp info dialog to hide video carousel slide if the url is empty