### PR TITLE
Use palletDisabled storage item

### DIFF
--- a/src/components/dapp-staking/DiscoverDappsTab.vue
+++ b/src/components/dapp-staking/DiscoverDappsTab.vue
@@ -136,10 +136,9 @@ export default defineComponent({
     const selectedDapp = ref<DappItem>();
     const selectedDappInfo = ref<StakeInfo>();
     const isPalletDisabled = computed(() => store.getters['dapps/getIsPalletDisabled']);
-    const currentNetworkIdx = computed(() => store.getters['general/networkIdx']);
 
     store.dispatch('dapps/getDapps');
-    store.dispatch('dapps/getStakingInfo', currentNetworkIdx.value);
+    store.dispatch('dapps/getStakingInfo');
 
     watchEffect(() => {
       if (isH160.value) {

--- a/src/store/dapp-staking/actions.ts
+++ b/src/store/dapp-staking/actions.ts
@@ -772,7 +772,7 @@ const actions: ActionTree<State, StateInterface> = {
     return result;
   },
 
-  async getStakingInfo({ commit, dispatch, rootState }, endpoint: number) {
+  async getStakingInfo({ commit, dispatch, rootState }) {
     await $api?.value?.isReady;
 
     try {
@@ -797,21 +797,15 @@ const actions: ActionTree<State, StateInterface> = {
         commit('setMaxNumberOfStakersPerContract', maxNumberOfStakersPerContract?.toNumber());
         commit('setUnbondingPeriod', unbondingPeriod?.toNumber());
         commit('setMaxUnlockingChunks', maxUnlockingChunks?.toNumber());
-
-        if (endpoint === endpointKey.ASTAR) {
-          commit('setIsPalletDisabled', true);
-        } else {
-          //  Check if dapps staking is enabled.
-          let isPalletDisabled = false;
-          try {
-            const isDisabled = await $api.value.query.dappsStaking.palletDisabled<bool>();
-            isPalletDisabled = isDisabled.valueOf();
-          } catch {
-            // palletDisabled storage item is not supported by a node;
-          }
-
-          commit('setIsPalletDisabled', isPalletDisabled);
+        let isPalletDisabled = false;
+        try {
+          const isDisabled = await $api.value.query.dappsStaking.palletDisabled<bool>();
+          isPalletDisabled = isDisabled.valueOf();
+        } catch {
+          // palletDisabled storage item is not supported by a node;
         }
+
+        commit('setIsPalletDisabled', isPalletDisabled);
       }
     } catch (e) {
       const error = e as unknown as Error;


### PR DESCRIPTION
**Pull Request Summary**

After runtime upgrade Astar (and all other networks) has palletDisabled storage item, so maintenance mode will be automatically tracked based on the item value.

![image](https://user-images.githubusercontent.com/8452361/163193386-3eaddd5e-0eca-4de6-841c-8bc82967e5b5.png)


**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

