### PR TITLE
Image size fix, clean markup

### DIFF
--- a/src/components/dapp-staking/Dapp.vue
+++ b/src/components/dapp-staking/Dapp.vue
@@ -24,7 +24,7 @@
           {{ dapp.name }}
         </div>
         <div class="tw-h-11 tw-w-48 description">
-          {{ dapp.description }}
+          {{ cleanMarkup(dapp.description) }}
         </div>
       </div>
     </div>
@@ -116,6 +116,16 @@ export default defineComponent({
         });
     };
 
+    const cleanMarkup = (text: string): string => {
+      // ATM remove only # and *
+      // Use split/join replacement method since replaceAll is not supported.
+      if (text) {
+        return text.split('*').join('').split('#').join('');
+      }
+
+      return text;
+    };
+
     watch(senderAddress, () => {
       getDappInfo();
     });
@@ -154,6 +164,7 @@ export default defineComponent({
       showStake,
       showStakeModal,
       handleStakeModalOpened,
+      cleanMarkup,
     };
   },
 });

--- a/src/components/dapp-staking/modals/ModalDappDetails.vue
+++ b/src/components/dapp-staking/modals/ModalDappDetails.vue
@@ -22,6 +22,7 @@
                 :key="index"
                 :img-src="url"
                 :name="index.toString()"
+                class="uncropped-image"
               />
               <template #control>
                 <q-carousel-control position="bottom-right" :offset="[18, 18]">
@@ -164,5 +165,11 @@ export default defineComponent({
 
 .scroll {
   height: 350px;
+}
+
+.uncropped-image {
+  background-size: contain; /* don't crop the image  */
+  background-repeat: no-repeat; /* only show the image one time  */
+  background-color: grey; /* color to fill empty space with  */
 }
 </style>


### PR DESCRIPTION
**Pull Request Summary**

Change the way how images are displayed in dapp info dialog

BEFORE
![image](https://user-images.githubusercontent.com/8452361/163325264-606d3b6b-a9c3-4680-933c-f8273a261ec6.png)

AFTER
![image](https://user-images.githubusercontent.com/8452361/163325296-99e64326-ec66-4a5d-ad26-5e877ecf0a11.png)

Removed Markup characters (*, #) from dapp panel.
I think we should have a separate database filed for short description

BEFORE
<img width="327" alt="image" src="https://user-images.githubusercontent.com/8452361/163325735-f270573a-9a35-49dc-b89d-2540837219af.png">

AFTER
<img width="304" alt="image" src="https://user-images.githubusercontent.com/8452361/163325527-3f148632-a5d2-4f71-9580-1f94af6344d6.png">



**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
