### PR TITLE
feat: added stakers number on the dashboard page

### DIFF
--- a/src/components/dashboard/ChartPanel.vue
+++ b/src/components/dashboard/ChartPanel.vue
@@ -8,7 +8,15 @@
         <span class="text--accent container--title--color">{{ $t(title) }}</span>
       </div>
       <div class="row chart--value">
-        <span class="text--value text-color--neon">{{ defaultValue }}</span>
+        <div>
+          <span class="text--value text-color--neon">{{ defaultValue }}</span>
+        </div>
+        <div v-if="secondValue">
+          <div v-if="secondValue === '0'">
+            <q-skeleton class="skeleton--staker" />
+          </div>
+          <span v-else class="text--second-value text-color--neon">{{ secondValue }}</span>
+        </div>
       </div>
       <div class="chart">
         <highcharts :options="chartOptions"></highcharts>
@@ -45,6 +53,11 @@ export default defineComponent({
     defaultValue: {
       type: String,
       required: true,
+    },
+    secondValue: {
+      type: String,
+      required: false,
+      default: '',
     },
     data: {
       type: Array as PropType<number[][] | null>,

--- a/src/components/dashboard/Dashboard.vue
+++ b/src/components/dashboard/Dashboard.vue
@@ -29,6 +29,7 @@
           :merged-tvl-data="filteredDappStakingTvl.merged"
           :handle-filter-changed="handleDappStakingTvlFilterChanged"
           :is-multiple-line="true"
+          :second-value="lenStakers"
         />
 
         <tvl-chart
@@ -40,7 +41,6 @@
           :handle-filter-changed="handleEcosystemTvlFilterChanged"
           :is-multiple-line="true"
         />
-
         <token-price-chart :network="chainInfo.chain" />
       </div>
     </div>
@@ -88,6 +88,7 @@ export default defineComponent({
       handleMergedTvlFilterChanged,
       filteredMergedTvl,
       mergedTvlAmount,
+      lenStakers,
     } = useTvlHistorical();
 
     const chainInfo = computed(() => {
@@ -143,6 +144,7 @@ export default defineComponent({
       handleMergedTvlFilterChanged,
       filteredMergedTvl,
       mergedTvlAmount,
+      lenStakers,
     };
   },
 });

--- a/src/components/dashboard/TvlChart.vue
+++ b/src/components/dashboard/TvlChart.vue
@@ -7,6 +7,7 @@
     :default-value="tvlValue"
     class="wrapper--chart"
     :is-multiple-line="isMultipleLine"
+    :second-value="secondValue"
     @filter-changed="handleFilterChanged"
   />
 </template>
@@ -31,6 +32,11 @@ export default defineComponent({
     tvlValue: {
       type: String,
       required: true,
+    },
+    secondValue: {
+      type: String,
+      required: false,
+      default: '',
     },
     tvlData: {
       type: Array as PropType<number[][] | null>,

--- a/src/components/dashboard/styles/chart-panel.scss
+++ b/src/components/dashboard/styles/chart-panel.scss
@@ -150,8 +150,9 @@
 
 .skeleton--chart {
   height: 367px;
+  border-radius: 6px;
   @media (min-width: $xxl) {
-    height: 417px;
+    height: 433px;
     width: 560px;
   }
 }

--- a/src/components/dashboard/styles/chart-panel.scss
+++ b/src/components/dashboard/styles/chart-panel.scss
@@ -140,6 +140,14 @@
   height: 120px;
 }
 
+.skeleton--staker {
+  width: 120px;
+  height: 39px;
+  @media (min-width: $sm) {
+    width: 200px;
+  }
+}
+
 .skeleton--chart {
   height: 367px;
   @media (min-width: $xxl) {
@@ -166,11 +174,22 @@
 
 .chart--value {
   padding: 8px 8px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .text--value {
   font-size: 26px;
   font-weight: 500;
+}
+
+.text--second-value {
+  font-size: 20px;
+  font-weight: 500;
+  @media (min-width: $sm) {
+    font-size: 26px;
+  }
 }
 
 .body--dark {

--- a/src/hooks/useTvlHistorical.ts
+++ b/src/hooks/useTvlHistorical.ts
@@ -1,10 +1,9 @@
 import { ApiPromise } from '@polkadot/api';
+import { $api } from 'src/boot/api';
+import { getDappStakers } from 'src/modules/dapp-staking';
 import { Duration, filterTvlData, getTvlData, mergeTvlArray } from 'src/modules/token-api';
 import { useStore } from 'src/store';
 import { computed, ref, watch } from 'vue';
-import { getDappStakers } from 'src/modules/dapp-staking';
-import { $api } from 'src/boot/api';
-import { useI18n } from 'vue-i18n';
 
 export function useTvlHistorical() {
   const mergedTvlAmount = ref<string>('');
@@ -21,7 +20,6 @@ export function useTvlHistorical() {
 
   const lenStakers = ref<string>('0');
 
-  const { t } = useI18n();
   const store = useStore();
   const network = computed(() => {
     const chainInfo = store.getters['general/chainInfo'];
@@ -30,9 +28,6 @@ export function useTvlHistorical() {
 
   const fetchDappStakers = async (api: ApiPromise) => {
     const result = await getDappStakers({ api });
-    console.log('result', result);
-    console.log('result.toLocaleString()', result.toLocaleString('en-US'));
-    // lenStakers.value = t('stakers', { value: result.toLocaleString('en-US') });
     lenStakers.value = `${result.toLocaleString('en-US')} stakers`;
   };
 

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -219,6 +219,7 @@ export default {
   dashboard: {
     dashboard: 'Dashboard',
     tvl: 'TVL',
+    stakers: '{value} stakers',
     block: {
       block: 'Block',
       blockHeight: 'Block Height',

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -219,7 +219,6 @@ export default {
   dashboard: {
     dashboard: 'Dashboard',
     tvl: 'TVL',
-    stakers: '{value} stakers',
     block: {
       block: 'Block',
       blockHeight: 'Block Height',

--- a/src/modules/dapp-staking/index.ts
+++ b/src/modules/dapp-staking/index.ts
@@ -1,0 +1,1 @@
+export { getDappStakers } from './utils';

--- a/src/modules/dapp-staking/utils/index.ts
+++ b/src/modules/dapp-staking/utils/index.ts
@@ -1,0 +1,14 @@
+import { ApiPromise } from '@polkadot/api';
+
+export const getDappStakers = async ({ api }: { api: ApiPromise }): Promise<number> => {
+  try {
+    // Memo: It takes a while to return the promise (10 ~ 15secs).
+    // Memo: We can cache this result and query via Token-API in the future.
+    const result = await api.query.dappsStaking.ledger.entries();
+    const numStakers = result.length;
+    return numStakers;
+  } catch (error) {
+    console.error(error);
+    return 0;
+  }
+};

--- a/src/modules/dapp-staking/utils/index.ts
+++ b/src/modules/dapp-staking/utils/index.ts
@@ -2,7 +2,7 @@ import { ApiPromise } from '@polkadot/api';
 
 export const getDappStakers = async ({ api }: { api: ApiPromise }): Promise<number> => {
   try {
-    // Memo: It takes a while to return the promise (10 ~ 15secs).
+    // Memo: It takes a while to return the promise (10 ~ 15 secs).
     // Memo: We can cache this result and query via Token-API in the future.
     const result = await api.query.dappsStaking.ledger.entries();
     const numStakers = result.length;


### PR DESCRIPTION
**Pull Request Summary**

* added the total number of dapp staking stakers on the dashboard page

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**

![image](https://user-images.githubusercontent.com/92044428/165675673-1e7532c7-dd26-4525-a5f5-fedcd7b1c06e.png)

**To-dos**
It takes a while to return the promise (10 ~ 15 secs) in [this](https://github.com/AstarNetwork/astar-apps/blob/b13cb55c7c69b9fae741544c07d914fad2a70244/src/modules/dapp-staking/utils/index.ts#L7) function. We can cache the result and query via Token-API in the future.