### PR TITLE
Withdraw feature fix

### DIFF
--- a/src/components/dapp-staking/StakePanel.vue
+++ b/src/components/dapp-staking/StakePanel.vue
@@ -144,7 +144,11 @@ export default defineComponent({
     const { decimal } = useChainMetadata();
     const { canUnbondWithdraw } = useUnbondWithdraw($api);
     const isH160 = computed(() => store.getters['general/isH160Formatted']);
-    const { callFunc, dispatchError, isCustomSig, customMsg } = useCustomSignature({});
+    const { callFunc, dispatchError, isCustomSig, customMsg } = useCustomSignature({
+      fn: () => {
+        store.commit('dapps/setUnlockingChunks', -1);
+      },
+    });
 
     const currentAddress = computed(() => store.getters['general/selectedAddress']);
     const substrateAccounts = computed(() => store.getters['general/substrateAccounts']);
@@ -263,7 +267,6 @@ export default defineComponent({
             fn && fn(getAddressEnum(props.dapp.address), amount);
 
           method && (await callFunc(method));
-          store.commit('setUnlockingChunks', -1);
           emitStakeChanged();
         } catch (e) {
           dispatchError((e as Error).message);
@@ -273,7 +276,6 @@ export default defineComponent({
       if (isCustomSig.value) {
         await unstakeCustomExtrinsic();
         showModal.value = false;
-        store.commit('setUnlockingChunks', -1);
       } else {
         const result = await store.dispatch(dispatchCommand, {
           api: $api?.value,

--- a/src/components/dapp-staking/StakePanel.vue
+++ b/src/components/dapp-staking/StakePanel.vue
@@ -273,6 +273,7 @@ export default defineComponent({
       if (isCustomSig.value) {
         await unstakeCustomExtrinsic();
         showModal.value = false;
+        store.commit('setUnlockingChunks', -1);
       } else {
         const result = await store.dispatch(dispatchCommand, {
           api: $api?.value,

--- a/src/components/dapp-staking/statistics/Withdraw.vue
+++ b/src/components/dapp-staking/statistics/Withdraw.vue
@@ -60,7 +60,11 @@ export default defineComponent({
   },
   setup() {
     const store = useStore();
-    const { callFunc, dispatchError, isCustomSig, customMsg } = useCustomSignature({});
+    const { callFunc, dispatchError, isCustomSig } = useCustomSignature({
+      fn: () => {
+        store.commit('dapps/setUnlockingChunks', -1);
+      },
+    });
     const selectedAccountAddress = computed(() => store.getters['general/selectedAddress']);
     const unlockingChunksCount = computed(() => store.getters['dapps/getUnlockingChunks']);
     const maxUnlockingChunks = computed(() => store.getters['dapps/getMaxUnlockingChunks']);
@@ -84,8 +88,7 @@ export default defineComponent({
       };
 
       if (isCustomSig.value) {
-        withdrawCustomExtrinsic();
-        store.commit('setUnlockingChunks', -1);
+        await withdrawCustomExtrinsic();
       } else {
         const result = await store.dispatch('dapps/withdrawUnbonded', {
           api: $api?.value,

--- a/src/components/dapp-staking/statistics/Withdraw.vue
+++ b/src/components/dapp-staking/statistics/Withdraw.vue
@@ -37,6 +37,7 @@
 
 <script lang="ts">
 import { defineComponent, onUnmounted, computed, ref, watch } from 'vue';
+import { SubmittableExtrinsic, SubmittableExtrinsicFunction } from '@polkadot/api/types';
 import BN from 'bn.js';
 import { $api } from 'boot/api';
 import { useStore } from 'src/store';
@@ -49,6 +50,7 @@ import { WithdrawParameters } from 'src/store/dapp-staking/actions';
 import FormatBalance from 'components/common/FormatBalance.vue';
 import ChunksModal from './ChunksModal.vue';
 import { useUnbondWithdraw } from 'src/hooks/useUnbondWithdraw';
+import { useCustomSignature } from 'src/hooks';
 
 export default defineComponent({
   components: {
@@ -58,6 +60,7 @@ export default defineComponent({
   },
   setup() {
     const store = useStore();
+    const { callFunc, dispatchError, isCustomSig, customMsg } = useCustomSignature({});
     const selectedAccountAddress = computed(() => store.getters['general/selectedAddress']);
     const unlockingChunksCount = computed(() => store.getters['dapps/getUnlockingChunks']);
     const maxUnlockingChunks = computed(() => store.getters['dapps/getMaxUnlockingChunks']);
@@ -69,11 +72,27 @@ export default defineComponent({
     const substrateAccounts = computed(() => store.getters['general/substrateAccounts']);
 
     const withdraw = async (): Promise<void> => {
-      const result = await store.dispatch('dapps/withdrawUnbonded', {
-        api: $api?.value,
-        senderAddress: selectedAccountAddress.value,
-        substrateAccounts: substrateAccounts.value,
-      } as WithdrawParameters);
+      const withdrawCustomExtrinsic = async () => {
+        try {
+          const fn: SubmittableExtrinsicFunction<'promise'> | undefined =
+            $api?.value?.tx.dappsStaking.withdrawUnbonded;
+          const method: SubmittableExtrinsic<'promise'> | undefined = fn && fn();
+          method && (await callFunc(method));
+        } catch (e) {
+          dispatchError((e as Error).message);
+        }
+      };
+
+      if (isCustomSig.value) {
+        withdrawCustomExtrinsic();
+        store.commit('setUnlockingChunks', -1);
+      } else {
+        const result = await store.dispatch('dapps/withdrawUnbonded', {
+          api: $api?.value,
+          senderAddress: selectedAccountAddress.value,
+          substrateAccounts: substrateAccounts.value,
+        } as WithdrawParameters);
+      }
     };
 
     const subscribeToEraChange = async (): Promise<VoidFn | undefined> => {

--- a/src/store/dapp-staking/actions.ts
+++ b/src/store/dapp-staking/actions.ts
@@ -490,7 +490,7 @@ const actions: ActionTree<State, StateInterface> = {
                 dispatch(
                   'general/showAlertMsg',
                   {
-                    msg: 'Sucessfully withdrawed',
+                    msg: 'Balance is sucessfully withdrawed.',
                     alertType: 'success',
                   },
                   { root: true }


### PR DESCRIPTION
**Pull Request Summary**
The following error happened to all users trying to withdraw unbondend tokens with their lockdrop account
<img width="282" alt="image" src="https://user-images.githubusercontent.com/8452361/165704190-f2bde5b1-feb8-4a09-b629-91b2f1037997.png">

I was able to reproduce error on Shibuya. Also I tested fix on Shibuya and worked for me. Test env Mac/Chrome/Metamask

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Fixes**
- unbonding for lockdrop participants
