### PR TITLE
Enable claim reward when compounding is on.

### DIFF
--- a/src/components/dapp-staking/ClaimAll.vue
+++ b/src/components/dapp-staking/ClaimAll.vue
@@ -7,9 +7,8 @@
       </IconTooltip>
     </div>
     <div class="widget-content">
-      <span v-if="!isCompounding">&nbsp;</span>
+      <span class="text--title">&nbsp;</span>
       <Button
-        v-if="!isCompounding"
         :small="true"
         :primary="true"
         :disabled="batchTxs.length === 0 || isLoading"
@@ -18,7 +17,6 @@
       >
         {{ $t('dappStaking.claim') }}
       </Button>
-      <span v-else class="text--title">{{ $t('dappStaking.autoCompoundingRewards') }}</span>
     </div>
   </div>
 </template>
@@ -28,7 +26,6 @@ import { fasMoneyCheckAlt } from '@quasar/extras/fontawesome-v5';
 import Button from 'src/components/common/Button.vue';
 import IconTooltip from 'components/common/IconTooltip.vue';
 import { useAccount, useClaimAll } from 'src/hooks';
-import { useCompoundRewards } from 'src/hooks/dapps-staking/useCompoundRewards';
 import { defineComponent } from 'vue';
 
 export default defineComponent({
@@ -39,7 +36,6 @@ export default defineComponent({
   setup() {
     const { claimAll, batchTxs, isLoading, isEnableIndividualClaim } = useClaimAll();
     const { currentAccount } = useAccount();
-    const { isCompounding } = useCompoundRewards();
 
     return {
       isEnableIndividualClaim,
@@ -48,7 +44,6 @@ export default defineComponent({
       batchTxs,
       isLoading,
       currentAccount,
-      isCompounding,
     };
   },
 });

--- a/src/hooks/custom-signature/message.ts
+++ b/src/hooks/custom-signature/message.ts
@@ -1,7 +1,6 @@
 import { hasExtrinsicFailedEvent } from './../../store/dapp-staking/actions';
 import { ISubmittableResult } from '@polkadot/types/types';
 import { calculateClaimedStaker } from '../helper/claim';
-import { useCompoundRewards } from 'src/hooks/dapps-staking/useCompoundRewards';
 import { Dispatch } from 'vuex';
 
 export enum TxType {
@@ -43,13 +42,7 @@ const dispatchClaimMessage = ({
         events: result.events,
         senderAddress,
       });
-      const { isCompounding } = useCompoundRewards();
-      let msg = `Successfully claimed ${totalClaimedStaker}`;
-
-      if (isCompounding.value) {
-        let msg = `Successfully re-staked ${totalClaimedStaker}`;
-      }
-
+      const msg = `Successfully claimed ${totalClaimedStaker}`;
       dispatch(
         'general/showAlertMsg',
         {

--- a/src/hooks/custom-signature/message.ts
+++ b/src/hooks/custom-signature/message.ts
@@ -1,6 +1,7 @@
 import { hasExtrinsicFailedEvent } from './../../store/dapp-staking/actions';
 import { ISubmittableResult } from '@polkadot/types/types';
 import { calculateClaimedStaker } from '../helper/claim';
+import { useCompoundRewards } from 'src/hooks/dapps-staking/useCompoundRewards';
 import { Dispatch } from 'vuex';
 
 export enum TxType {
@@ -42,7 +43,13 @@ const dispatchClaimMessage = ({
         events: result.events,
         senderAddress,
       });
-      const msg = `Successfully claimed ${totalClaimedStaker}`;
+      const { isCompounding } = useCompoundRewards();
+      let msg = `Successfully claimed ${totalClaimedStaker}`;
+
+      if (isCompounding.value) {
+        let msg = `Successfully re-staked ${totalClaimedStaker}`;
+      }
+
       dispatch(
         'general/showAlertMsg',
         {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -99,9 +99,7 @@ export default {
     apr: 'APR',
     ttlPendingRewards: 'Your Pending Rewards',
     autoCompound: 'Auto Compound',
-    autoCompoundingRewards: 'Auto-compounding the rewards',
-    autoCompoundingTooltip:
-      'By turning on the Auto compound, your rewards will automatically re-stake.',
+    autoCompoundingTooltip: 'By turning on the Auto compound, your clamed rewards will re-stake.',
     view: 'View',
     unclaimedRewards: 'Unclaimed Rewards',
     unclaimedRewardsTooltip: 'Currently we are working on displaying number of unclaimed era.',

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -99,7 +99,8 @@ export default {
     apr: 'APR',
     ttlPendingRewards: 'Your Pending Rewards',
     autoCompound: 'Auto Compound',
-    autoCompoundingTooltip: 'By turning on the Auto compound, your clamed rewards will re-stake.',
+    autoCompoundingTooltip:
+      'By turning on the Auto compound, your clamed rewards will re-stake on claim.',
     view: 'View',
     unclaimedRewards: 'Unclaimed Rewards',
     unclaimedRewardsTooltip: 'Currently we are working on displaying number of unclaimed era.',


### PR DESCRIPTION
**Pull Request Summary**

Claim reward button is visible no matter of compounding status.
<img width="647" alt="image" src="https://user-images.githubusercontent.com/8452361/166313197-00a6c1d5-6711-45b8-af70-73229aca594f.png">


If user claim rewards when compounding is on, rewards are added to balance and restaked.
If user claim rewards when compounding is off, rewards are only added to balance.

@Dinonard  please check the above statement

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Changes**
- claim button visibility doesn't depend on compounding status.
