### PR TITLE
Claim all disabled when claimable awards available

### DIFF
--- a/src/components/dapp-staking/styles/user-rewards-widget.scss
+++ b/src/components/dapp-staking/styles/user-rewards-widget.scss
@@ -4,10 +4,6 @@
   font-size: 16px;
   margin-bottom: 12px;
   display: flex;
-  
-  @media (max-width: 1100px) {
-    height: 80px;
-  }
 }
 
 .widget-container {

--- a/src/hooks/helper/claim.ts
+++ b/src/hooks/helper/claim.ts
@@ -66,8 +66,7 @@ const getNumberOfUnclaimedEra = async ({
     );
 
     if (data && !data.isEmpty) {
-      const stakerInfo = data;
-      const stakes = stakerInfo && stakerInfo.stakes;
+      const stakes = data && data.stakes;
 
       for (let i = 0; i < stakes.length; i++) {
         const { era, staked } = stakes[i];

--- a/src/hooks/helper/claim.ts
+++ b/src/hooks/helper/claim.ts
@@ -1,6 +1,6 @@
 import { ApiPromise } from '@polkadot/api';
 import { Option, Struct } from '@polkadot/types';
-import { EventRecord } from '@polkadot/types/interfaces';
+import { EventRecord, Balance } from '@polkadot/types/interfaces';
 import BN from 'bn.js';
 import { getAddressEnum } from './../../store/dapp-staking/calculation';
 import { ExtrinsicPayload } from './index';
@@ -12,9 +12,13 @@ interface ContractEraStake extends Struct {
   readonly total: string;
 }
 
+export interface EraStake extends Struct {
+  staked: Balance;
+  era: number;
+}
+
 export interface GeneralStakerInfo extends Struct {
-  // Todo: fix type annotation
-  readonly stakes: any[];
+  readonly stakes: EraStake[];
 }
 
 export interface RegisteredDapps extends Struct {
@@ -56,18 +60,18 @@ const getNumberOfUnclaimedEra = async ({
 }): Promise<number> => {
   let numberOfUnclaimedEra = 0;
   try {
-    const data = await api.query.dappsStaking.generalStakerInfo<Option<GeneralStakerInfo>>(
+    const data = await api.query.dappsStaking.generalStakerInfo<GeneralStakerInfo>(
       senderAddress,
       getAddressEnum(dappAddress)
     );
 
     if (data && !data.isEmpty) {
-      const stakerInfo: GeneralStakerInfo = data.toHuman() as any;
+      const stakerInfo = data;
       const stakes = stakerInfo && stakerInfo.stakes;
 
       for (let i = 0; i < stakes.length; i++) {
         const { era, staked } = stakes[i];
-        if (staked === '0') continue;
+        if (staked.eq(new BN(0))) continue;
         const nextEraData = stakes[i + 1] ?? null;
         const nextEra = nextEraData && nextEraData.era;
         const isLastEra = i === stakes.length - 1;

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -98,7 +98,7 @@ export default {
     stakerApr: 'APR: {value}%',
     apr: 'APR',
     ttlPendingRewards: 'Your Pending Rewards',
-    autoCompound: 'Auto-compound after claiming',
+    autoCompound: 'Re-stake after claiming',
     autoCompoundingTooltip:
       'By turning on the Auto compound, your rewards will re-stake after claiming.',
     view: 'View',


### PR DESCRIPTION
**Pull Request Summary**

This bug was caused because era number was converted to string and handled as such in getNumberOfUnclaimedEra.
When era was above 1000 it was formatted like '1,000' which caused math operations to return NaN.

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
