### PR TITLE
fix: make the XCM section higher than the assets section

### DIFF
--- a/src/components/assets/Assets.vue
+++ b/src/components/assets/Assets.vue
@@ -13,12 +13,12 @@
           />
         </div>
         <div v-else class="container--assets">
-          <NativeAssetList />
           <XcmNativeAssetList
             v-if="isEnableXcm"
             :xcm-assets="xcmAssets"
             :handle-update-xcm-token-balances="handleUpdateXcmTokenBalances"
           />
+          <NativeAssetList />
         </div>
       </div>
     </div>
@@ -61,13 +61,22 @@ export default defineComponent({
       return getProviderIndex(chain);
     });
 
+    const isShibuya = computed(() => currentNetworkIdx.value === endpointKey.SHIBUYA);
+
     const isEnableXcm = computed(
-      () => currentNetworkIdx.value !== endpointKey.SHIBUYA && xcmAssets.value.length > 0
+      () => !isShibuya.value && xcmAssets.value && xcmAssets.value.length > 0
     );
 
     const setIsDisplay = async (): Promise<void> => {
       const address = localStorage.getItem(LOCAL_STORAGE.SELECTED_ADDRESS);
       const isEthereumExtension = address === 'Ethereum Extension';
+      const isLoading = !isShibuya.value && !isEnableXcm.value;
+
+      if (isLoading) {
+        isDisplay.value = false;
+        return;
+      }
+
       if (!isDisplay.value && isEthereumExtension) {
         // Memo: Wait for update the `isH160` state
         const secDelay = 1 * 1000;

--- a/src/components/assets/Assets.vue
+++ b/src/components/assets/Assets.vue
@@ -26,16 +26,14 @@
 </template>
 <script lang="ts">
 import Account from 'src/components/assets/Account.vue';
+import EvmAssetList from 'src/components/assets/EvmAssetList.vue';
 import NativeAssetList from 'src/components/assets/NativeAssetList.vue';
 import XcmNativeAssetList from 'src/components/assets/XcmNativeAssetList.vue';
-import EvmAssetList from 'src/components/assets/EvmAssetList.vue';
-
-import { useStore } from 'src/store';
-import { defineComponent, computed, ref, watchEffect } from 'vue';
-import { useCbridgeV2, useXcmAssets } from 'src/hooks';
-import { LOCAL_STORAGE } from 'src/config/localStorage';
-import { wait } from 'src/hooks/helper/common';
 import { endpointKey, getProviderIndex } from 'src/config/chainEndpoints';
+import { LOCAL_STORAGE } from 'src/config/localStorage';
+import { useCbridgeV2, useXcmAssets } from 'src/hooks';
+import { useStore } from 'src/store';
+import { computed, defineComponent, ref, watchEffect } from 'vue';
 
 export default defineComponent({
   components: {
@@ -72,11 +70,15 @@ export default defineComponent({
       const isEthereumExtension = address === 'Ethereum Extension';
       const isLoading = !isShibuya.value && !isEnableXcm.value;
 
-      if (isLoading) return;
+      if (isLoading) {
+        isDisplay.value = false;
+        store.commit('general/setLoading', true);
+        return;
+      } else {
+        store.commit('general/setLoading', false);
+      }
+
       if (!isDisplay.value && isEthereumExtension) {
-        // Memo: Wait for updating the `isH160` state
-        const secDelay = 1 * 1000;
-        await wait(secDelay);
         isDisplay.value = true;
       } else {
         isDisplay.value = true;

--- a/src/components/assets/Assets.vue
+++ b/src/components/assets/Assets.vue
@@ -74,7 +74,7 @@ export default defineComponent({
 
       if (isLoading) return;
       if (!isDisplay.value && isEthereumExtension) {
-        // Memo: Wait for update the `isH160` state
+        // Memo: Wait for updating the `isH160` state
         const secDelay = 1 * 1000;
         await wait(secDelay);
         isDisplay.value = true;

--- a/src/components/assets/Assets.vue
+++ b/src/components/assets/Assets.vue
@@ -72,11 +72,7 @@ export default defineComponent({
       const isEthereumExtension = address === 'Ethereum Extension';
       const isLoading = !isShibuya.value && !isEnableXcm.value;
 
-      if (isLoading) {
-        isDisplay.value = false;
-        return;
-      }
-
+      if (isLoading) return;
       if (!isDisplay.value && isEthereumExtension) {
         // Memo: Wait for update the `isH160` state
         const secDelay = 1 * 1000;

--- a/src/components/assets/Assets.vue
+++ b/src/components/assets/Assets.vue
@@ -32,6 +32,7 @@ import XcmNativeAssetList from 'src/components/assets/XcmNativeAssetList.vue';
 import { endpointKey, getProviderIndex } from 'src/config/chainEndpoints';
 import { LOCAL_STORAGE } from 'src/config/localStorage';
 import { useCbridgeV2, useXcmAssets } from 'src/hooks';
+import { wait } from 'src/hooks/helper/common';
 import { useStore } from 'src/store';
 import { computed, defineComponent, ref, watchEffect } from 'vue';
 
@@ -70,15 +71,18 @@ export default defineComponent({
       const isEthereumExtension = address === 'Ethereum Extension';
       const isLoading = !isShibuya.value && !isEnableXcm.value;
 
-      if (isLoading) {
-        isDisplay.value = false;
-        store.commit('general/setLoading', true);
-        return;
-      } else {
-        store.commit('general/setLoading', false);
-      }
+      // if (isLoading) {
+      //   isDisplay.value = false;
+      //   store.commit('general/setLoading', true);
+      //   return;
+      // } else {
+      //   store.commit('general/setLoading', false);
+      // }
 
       if (!isDisplay.value && isEthereumExtension) {
+        // Memo: Wait for update the `isH160` state
+        const secDelay = 1 * 1000;
+        await wait(secDelay);
         isDisplay.value = true;
       } else {
         isDisplay.value = true;

--- a/src/components/assets/Assets.vue
+++ b/src/components/assets/Assets.vue
@@ -71,13 +71,14 @@ export default defineComponent({
       const isEthereumExtension = address === 'Ethereum Extension';
       const isLoading = !isShibuya.value && !isEnableXcm.value;
 
-      // if (isLoading) {
-      //   isDisplay.value = false;
-      //   store.commit('general/setLoading', true);
-      //   return;
-      // } else {
-      //   store.commit('general/setLoading', false);
-      // }
+      if (isLoading) {
+        isDisplay.value = false;
+        // Memo: isEthereumExtension -> loading state is controlled under useCbridgeV2.ts
+        !isEthereumExtension && store.commit('general/setLoading', true);
+        return;
+      } else {
+        !isEthereumExtension && store.commit('general/setLoading', false);
+      }
 
       if (!isDisplay.value && isEthereumExtension) {
         // Memo: Wait for update the `isH160` state

--- a/src/components/assets/styles/assets.scss
+++ b/src/components/assets/styles/assets.scss
@@ -2,6 +2,7 @@
 
 .wrapper--assets {
   position: relative;
+  margin-top: 16px;
   @media (min-width: $xxl) {
     display: flex;
     justify-content: center;
@@ -29,7 +30,7 @@
 
 .container--assets {
   display: grid;
-  row-gap: 56px;
+  row-gap: 32px;
   margin-bottom: 24px;
   @media (min-width: $xxl) {
     width: $container-max-width;

--- a/src/hooks/c-bridge/useCbridgeV2.ts
+++ b/src/hooks/c-bridge/useCbridgeV2.ts
@@ -22,6 +22,9 @@ type Token = CbridgeCurrency | Erc20Token;
 export function useCbridgeV2() {
   const tokens = ref<Token[] | null>(null);
   const ttlErc20Amount = ref<number>(0);
+  const isCalculated = ref<boolean>(false);
+  const startCalculation = ref<boolean>(false);
+
   const store = useStore();
   const isH160 = computed(() => store.getters['general/isH160Formatted']);
   const { currentAccount } = useAccount();
@@ -205,6 +208,8 @@ export function useCbridgeV2() {
       await updateTokenBalances({ userAddress: currentAccount.value });
     } catch (error) {
       console.error(error);
+    } finally {
+      isCalculated.value = true;
     }
   };
 
@@ -217,8 +222,10 @@ export function useCbridgeV2() {
     [tokens],
     () => {
       const isInitialErc20Amount =
-        tokens.value && tokens.value.length > 0 && ttlErc20Amount.value === 0;
+        tokens.value && tokens.value.length > 0 && !isCalculated.value && !startCalculation.value;
       if (isInitialErc20Amount) {
+        // Memo: to avoid calling this function twice
+        startCalculation.value = true;
         handleUpdateTokenBalances();
       }
     },


### PR DESCRIPTION
**Pull Request Summary**

* fix: make the XCM section higher than the assets section
* styling: modified the gap (height) between panels on the assets page
fix: prevents an endless loop while calculating the ERC20 token amount (for the users who haven't held any ERC20 token)

<img width="1273" alt="image" src="https://user-images.githubusercontent.com/92044428/169234420-bae594ae-89fe-48be-b2ce-e501657bf8ee.png">


**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes


**Fixes**
* fix: prevents an endless loop while calculating the ERC20 token amount (for the users who haven't held any ERC20 token)

