### PR TITLE
refactor: fetch the native tip data from the 'tip' property rather than calculating by the portal

### DIFF
--- a/src/modules/gas-api/index.ts
+++ b/src/modules/gas-api/index.ts
@@ -17,9 +17,9 @@ export interface ApiGasNow {
 }
 
 interface PriceData {
-  slow: number;
-  average: number;
-  fast: number;
+  slow: string;
+  average: string;
+  fast: string;
   timestamp: number;
   eip1559: Eip1559;
   tip: Fee;
@@ -27,13 +27,13 @@ interface PriceData {
 
 interface Eip1559 {
   priorityFeePerGas: Fee;
-  baseFeePerGas: number;
+  baseFeePerGas: string;
 }
 
 interface Fee {
-  slow: number;
-  average: number;
-  fast: number;
+  slow: string;
+  average: string;
+  fast: string;
 }
 
 export type Speed = 'slow' | 'average' | 'fast';

--- a/src/modules/gas-api/index.ts
+++ b/src/modules/gas-api/index.ts
@@ -22,14 +22,15 @@ interface PriceData {
   fast: number;
   timestamp: number;
   eip1559: Eip1559;
+  tip: Fee;
 }
 
 interface Eip1559 {
-  priorityFeePerGas: PriorityFee;
+  priorityFeePerGas: Fee;
   baseFeePerGas: number;
 }
 
-interface PriorityFee {
+interface Fee {
   slow: number;
   average: number;
   fast: number;

--- a/src/modules/gas-api/utils/index.spec.ts
+++ b/src/modules/gas-api/utils/index.spec.ts
@@ -4,6 +4,6 @@ import { formatTip } from './index';
 describe('Test Gas-Api utils', () => {
   it('convert the native tip amount from wei', () => {
     // Memo: toBe -> unit: ASTR(same as ETH)
-    expect(formatTip(10000000000000)).toBe('0.00001');
+    expect(formatTip('10000000000000')).toBe('0.00001');
   });
 });

--- a/src/modules/gas-api/utils/index.spec.ts
+++ b/src/modules/gas-api/utils/index.spec.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
-import { priorityFeeToTip } from './index';
+import { formatTip } from './index';
 
 describe('Test Gas-Api utils', () => {
-  it('calculate native tip amount from eip1559 priorityFeePerGas', () => {
+  it('convert the native tip amount from wei', () => {
     // Memo: toBe -> unit: ASTR(same as ETH)
-    expect(priorityFeeToTip(223353420029)).toBe('0.000223353420029');
-    expect(priorityFeeToTip(115000000)).toBe('0.000000115');
-    expect(priorityFeeToTip(50000000000000)).toBe('0.05');
+    expect(formatTip(10000000000000)).toBe('0.00001');
   });
 });

--- a/src/modules/gas-api/utils/index.ts
+++ b/src/modules/gas-api/utils/index.ts
@@ -53,8 +53,8 @@ export const getEvmGasCost = async ({
 };
 
 // Ref: https://stakesg.slack.com/archives/C028YNW1PED/p1652346083299849?thread_ts=1652338487.358459&cid=C028YNW1PED
-export const priorityFeeToTip = (fee: number): string => {
-  const price = ethers.utils.formatUnits(String(fee), 15).toString();
+export const formatTip = (fee: number): string => {
+  const price = ethers.utils.formatEther(String(fee));
   // Memo: throw an error whenever provided price is too way expensive
   if (Number(price) > 1) {
     throw Error('Calculated tip amount is more than 1 ASTR/SDN');
@@ -77,11 +77,12 @@ export const fetchEvmGasPrice = async ({
     if (!data || data.code !== 200) {
       throw Error('something went wrong');
     }
+    const { tip } = data.data;
     const { priorityFeePerGas } = data.data.eip1559;
     const nativeTipPrice = {
-      slow: priorityFeeToTip(priorityFeePerGas.slow),
-      average: priorityFeeToTip(priorityFeePerGas.average),
-      fast: priorityFeeToTip(priorityFeePerGas.fast),
+      slow: formatTip(tip.slow),
+      average: formatTip(tip.average),
+      fast: formatTip(tip.fast),
     };
 
     if (isEip1559) {
@@ -128,9 +129,9 @@ export const fetchEvmGasPrice = async ({
       baseFeePerGas: '0',
     };
     const nativeTipPrice = {
-      slow: priorityFeeToTip(10000000000),
-      average: priorityFeeToTip(50000000000),
-      fast: priorityFeeToTip(50000000000000),
+      slow: formatTip(10000000000000),
+      average: formatTip(50000000000000),
+      fast: formatTip(5000000000000000),
     };
     return { evmGasPrice, nativeTipPrice };
   }

--- a/src/modules/gas-api/utils/index.ts
+++ b/src/modules/gas-api/utils/index.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { BN } from 'bn.js';
 import { ethers } from 'ethers';
 import Web3 from 'web3';
 import { TransactionConfig } from 'web3-eth';
@@ -41,20 +42,21 @@ export const getEvmGasCost = async ({
         data: encodedData,
       };
 
-  const estimatedGas = await web3.eth.estimateGas(tx);
+  const numEstimatedGas = await web3.eth.estimateGas(tx);
+  const estimatedGas = new BN(numEstimatedGas);
   const data = {
     ...evmGasPrice,
-    slow: ethers.utils.formatEther(estimatedGas * Number(evmGasPrice.slow)),
-    average: ethers.utils.formatEther(estimatedGas * Number(evmGasPrice.average)),
-    fast: ethers.utils.formatEther(estimatedGas * Number(evmGasPrice.fast)),
+    slow: ethers.utils.formatEther(estimatedGas.mul(new BN(evmGasPrice.slow)).toString()),
+    average: ethers.utils.formatEther(estimatedGas.mul(new BN(evmGasPrice.average)).toString()),
+    fast: ethers.utils.formatEther(estimatedGas.mul(new BN(evmGasPrice.fast)).toString()),
   };
 
   return data;
 };
 
 // Ref: https://stakesg.slack.com/archives/C028YNW1PED/p1652346083299849?thread_ts=1652338487.358459&cid=C028YNW1PED
-export const formatTip = (fee: number): string => {
-  const price = ethers.utils.formatEther(String(fee));
+export const formatTip = (fee: string): string => {
+  const price = ethers.utils.formatEther(fee);
   // Memo: throw an error whenever provided price is too way expensive
   if (Number(price) > 1) {
     throw Error('Calculated tip amount is more than 1 ASTR/SDN');
@@ -87,10 +89,10 @@ export const fetchEvmGasPrice = async ({
 
     if (isEip1559) {
       const evmGasPrice = {
-        slow: String(priorityFeePerGas.slow),
-        average: String(priorityFeePerGas.average),
-        fast: String(priorityFeePerGas.fast),
-        baseFeePerGas: String(data.data.eip1559.baseFeePerGas),
+        slow: priorityFeePerGas.slow,
+        average: priorityFeePerGas.average,
+        fast: priorityFeePerGas.fast,
+        baseFeePerGas: data.data.eip1559.baseFeePerGas,
       };
       return {
         evmGasPrice,
@@ -99,9 +101,9 @@ export const fetchEvmGasPrice = async ({
     } else {
       const { slow, average, fast } = data.data;
       const evmGasPrice = {
-        slow: String(slow),
-        average: String(average),
-        fast: String(fast),
+        slow: slow,
+        average: average,
+        fast: fast,
         baseFeePerGas: '0',
       };
       return {
@@ -129,9 +131,9 @@ export const fetchEvmGasPrice = async ({
       baseFeePerGas: '0',
     };
     const nativeTipPrice = {
-      slow: formatTip(10000000000000),
-      average: formatTip(50000000000000),
-      fast: formatTip(5000000000000000),
+      slow: formatTip('10000000000000'),
+      average: formatTip('50000000000000'),
+      fast: formatTip('5000000000000000'),
     };
     return { evmGasPrice, nativeTipPrice };
   }


### PR DESCRIPTION
**Pull Request Summary**

* refactor: fetch the native tip data from the `tip` property rather than calculating by the portal

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [x] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**
* refactor: fetch the native tip data from the tip property rather than calculating by the portal

![image](https://user-images.githubusercontent.com/92044428/169476479-29805261-f34c-4790-8920-ad06224e09fb.png)
