### PR TITLE
fix: reverse the position of XCM destination tab

### DIFF
--- a/src/components/assets/modals/ModalXcmBridge.vue
+++ b/src/components/assets/modals/ModalXcmBridge.vue
@@ -10,20 +10,20 @@
       <div class="row--mode-tab">
         <div
           class="box--bridge-option"
-          :class="isNativeBridge ? 'selected-bridge-option' : 'unselected-bridge-option'"
-          @click="setIsNativeBridge(true)"
-        >
-          <span class="text--title" :class="isNativeBridge && 'text-color--neon'">
-            {{ $t('assets.modals.depositToNative') }}
-          </span>
-        </div>
-        <div
-          class="box--bridge-option"
           :class="!isNativeBridge ? 'selected-bridge-option' : 'unselected-bridge-option'"
           @click="setIsNativeBridge(false)"
         >
           <span class="text--title" :class="!isNativeBridge && 'text-color--neon'">
             {{ $t('assets.modals.depositToEvm') }}
+          </span>
+        </div>
+        <div
+          class="box--bridge-option"
+          :class="isNativeBridge ? 'selected-bridge-option' : 'unselected-bridge-option'"
+          @click="setIsNativeBridge(true)"
+        >
+          <span class="text--title" :class="isNativeBridge && 'text-color--neon'">
+            {{ $t('assets.modals.depositToNative') }}
           </span>
         </div>
       </div>

--- a/src/components/assets/modals/ModalXcmBridge.vue
+++ b/src/components/assets/modals/ModalXcmBridge.vue
@@ -107,20 +107,20 @@
           </div>
           <div class="icon--help">
             <IconHelp />
+            <q-tooltip class="box--tooltip-warning">
+              <div>
+                <span v-if="existentialDeposit"
+                  >{{
+                    $t('assets.modals.xcmWarning.tooltip', {
+                      amount: Number(existentialDeposit.amount),
+                      symbol: existentialDeposit.symbol,
+                      network: existentialDeposit.chain,
+                    })
+                  }}
+                </span>
+              </div>
+            </q-tooltip>
           </div>
-          <q-tooltip class="box--tooltip-warning">
-            <div>
-              <span v-if="existentialDeposit"
-                >{{
-                  $t('assets.modals.xcmWarning.tooltip', {
-                    amount: Number(existentialDeposit.amount),
-                    symbol: existentialDeposit.symbol,
-                    network: existentialDeposit.chain,
-                  })
-                }}
-              </span>
-            </div>
-          </q-tooltip>
         </div>
         <div class="row--warning">
           <div class="column--title">

--- a/src/hooks/xcm/useXcmBridge.ts
+++ b/src/hooks/xcm/useXcmBridge.ts
@@ -61,6 +61,7 @@ export function useXcmBridge(selectedToken: Ref<ChainAsset>) {
     isDisabledBridge.value = true;
     amount.value = null;
     errMsg.value = '';
+    destEvmAddress.value = '';
   };
 
   const getRelayChainNativeBal = async (): Promise<string> => {

--- a/src/hooks/xcm/useXcmBridge.ts
+++ b/src/hooks/xcm/useXcmBridge.ts
@@ -37,7 +37,7 @@ export function useXcmBridge(selectedToken: Ref<ChainAsset>) {
   const amount = ref<string | null>(null);
   const errMsg = ref<string>('');
   const isDisabledBridge = ref<boolean>(true);
-  const isNativeBridge = ref<boolean>(true);
+  const isNativeBridge = ref<boolean>(false);
   const destEvmAddress = ref<string>('');
   const existentialDeposit = ref<ExistentialDeposit | null>(null);
 


### PR DESCRIPTION
**Pull Request Summary**

* reverse the position of XCM destination tab
* make `Deposit to EVM` the default option

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**
=Before=
![image](https://user-images.githubusercontent.com/92044428/170441736-6e14926b-ad19-47df-a3ab-261339b363e3.png)

=After=
![image](https://user-images.githubusercontent.com/92044428/170441801-a40d1483-708a-478d-a107-6300c0f943b6.png)



