### PR TITLE
fix: displaying duplicated account when the account has been imported to more than 2 wallets

### DIFF
--- a/src/boot/api.ts
+++ b/src/boot/api.ts
@@ -79,19 +79,29 @@ export default boot(async ({ store }) => {
   $api = api;
   $endpoint.value = endpoint;
 
+  const seen = new Set();
+  const accountMap: { address: string; name: string; source: string }[] = [];
   keyring.accounts.subject.subscribe((accounts) => {
     if (accounts) {
       const accountArray = objToArray(accounts);
-      const accountMap = accountArray.map((account) => {
+      accountArray.forEach((account) => {
         const { address, meta } = account.json;
-        return {
-          address,
-          name: meta.name.replace('\n              ', ''),
-          source: meta.source,
-        };
-      });
+        const source = meta.source;
+        const addressWithSource = address + source;
+        const isSeen = seen.has(addressWithSource);
 
-      store.commit('general/setSubstrateAccounts', accountMap);
+        if (!isSeen) {
+          const data = {
+            address,
+            name: meta.name.replace('\n              ', ''),
+            source,
+          };
+
+          seen.add(addressWithSource);
+          accountMap.push(data);
+          store.commit('general/setSubstrateAccounts', accountMap);
+        }
+      });
     }
   });
 


### PR DESCRIPTION
**Pull Request Summary**

* fix: displaying duplicated account when the account has been imported to more than 2 wallets
  *  issue: https://github.com/AstarNetwork/astar-apps/issues/360 
    *  CC: @fiexer  

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [x] tested on mobile devices

**Fix**

=Before=
`keyring.accounts.subject.subscribe` overwrites duplicated wallet addresses by default.

![image](https://user-images.githubusercontent.com/92044428/172127778-b1446af1-dbc0-48e0-90ea-f7c73c886ae8.png)

