### PR TITLE
feat: leaving safe amount (existential deposit * 1.1) in relaychain after XCM transfer

### DIFF
--- a/src/hooks/xcm/useXcmBridge.ts
+++ b/src/hooks/xcm/useXcmBridge.ts
@@ -52,6 +52,7 @@ export function useXcmBridge(selectedToken: Ref<ChainAsset>) {
   const evmDestAddress = ref<string>('');
   const evmDestAddressBalance = ref<number>(0);
   const fromAddressBalance = ref<number>(0);
+  const relaychainBal = ref<number>(0);
 
   const { t } = useI18n();
   const store = useStore();
@@ -125,6 +126,28 @@ export function useXcmBridge(selectedToken: Ref<ChainAsset>) {
     existentialDeposit.value = result;
   };
 
+  const setRelaychainBal = async (): Promise<void> => {
+    if (!relayChainApi || !selectedToken.value) return;
+    await relayChainApi.isReady();
+    const rawBalance = await getRelayChainNativeBal();
+    const decimals = Number(String(selectedToken.value.metadata.decimals));
+    const balance = ethers.utils.formatUnits(rawBalance, decimals).toString();
+    relaychainBal.value = Number(balance);
+  };
+
+  const checkIsEnoughEd = (amount: number): boolean => {
+    if (!existentialDeposit.value?.relaychainMinBal) return false;
+
+    if (isDeposit.value) {
+      const relayBalAfterTransfer = relaychainBal.value - amount;
+      const result = relayBalAfterTransfer > existentialDeposit.value.relaychainMinBal;
+      return result;
+    } else {
+      const result = relaychainBal.value > existentialDeposit.value.relaychainMinBal;
+      return result;
+    }
+  };
+
   const inputHandler = (event: any): void => {
     amount.value = event.target.value;
     // check if recipient account has non-zero native asset. (it cannot be transferred to an account with 0 nonce)
@@ -132,7 +155,8 @@ export function useXcmBridge(selectedToken: Ref<ChainAsset>) {
       !amount.value ||
       Number(amount.value) === 0 ||
       Number(amount.value) > fromAddressBalance.value ||
-      balance.value.lten(0);
+      balance.value.lten(0) ||
+      !checkIsEnoughEd(Number(amount.value));
     errMsg.value = '';
   };
 
@@ -276,7 +300,6 @@ export function useXcmBridge(selectedToken: Ref<ChainAsset>) {
           }
           console.log('Send assets from Parachain(EVM)');
         } else {
-          console.log('Send assets from Parachain');
           const paraChainApi = new ParachainApi($api!!);
           const decimals = Number(selectedToken.value.metadata.decimals);
           const txCall = paraChainApi.transferToRelaychain(
@@ -315,12 +338,7 @@ export function useXcmBridge(selectedToken: Ref<ChainAsset>) {
     if (!selectedToken.value) return;
 
     if (isDeposit.value) {
-      if (!relayChainApi) return;
-      await relayChainApi.isReady();
-      const rawBalance = await getRelayChainNativeBal();
-      const decimals = Number(String(selectedToken.value.metadata.decimals));
-      const balance = ethers.utils.formatUnits(rawBalance, decimals).toString();
-      fromAddressBalance.value = Number(balance);
+      fromAddressBalance.value = relaychainBal.value;
     } else {
       const address = currentAccount.value;
       // Memo: Withdraw
@@ -378,7 +396,7 @@ export function useXcmBridge(selectedToken: Ref<ChainAsset>) {
   );
 
   watchEffect(async () => {
-    await Promise.all([updateFromAddressBalance(), setEvmDestAddressBalance()]);
+    await Promise.all([updateFromAddressBalance(), setEvmDestAddressBalance(), setRelaychainBal()]);
   });
 
   watchEffect(async () => {
@@ -386,7 +404,7 @@ export function useXcmBridge(selectedToken: Ref<ChainAsset>) {
   });
 
   const handleUpdate = setInterval(async () => {
-    await Promise.all([updateFromAddressBalance(), setEvmDestAddressBalance()]);
+    await Promise.all([updateFromAddressBalance(), setEvmDestAddressBalance(), setRelaychainBal()]);
   }, 20 * 1000);
 
   onUnmounted(() => {

--- a/src/hooks/xcm/useXcmBridge.ts
+++ b/src/hooks/xcm/useXcmBridge.ts
@@ -136,15 +136,14 @@ export function useXcmBridge(selectedToken: Ref<ChainAsset>) {
   };
 
   const checkIsEnoughEd = (amount: number): boolean => {
-    if (!existentialDeposit.value?.relaychainMinBal) return false;
+    const relaychainMinBal = existentialDeposit.value?.relaychainMinBal;
+    if (!relaychainMinBal) return false;
 
     if (isDeposit.value) {
       const relayBalAfterTransfer = relaychainBal.value - amount;
-      const result = relayBalAfterTransfer > existentialDeposit.value.relaychainMinBal;
-      return result;
+      return relayBalAfterTransfer > relaychainMinBal;
     } else {
-      const result = relaychainBal.value > existentialDeposit.value.relaychainMinBal;
-      return result;
+      return relaychainBal.value > relaychainMinBal;
     }
   };
 

--- a/src/modules/xcm/index.ts
+++ b/src/modules/xcm/index.ts
@@ -21,6 +21,8 @@ export interface ExistentialDeposit {
   amount: string;
   chain: string;
   symbol: string;
+  // Memo: minimum balance keeps in relaychain
+  relaychainMinBal: number;
 }
 
 // Ref: RPC calls -> system -> chain()

--- a/src/modules/xcm/utils/index.ts
+++ b/src/modules/xcm/utils/index.ts
@@ -54,6 +54,18 @@ export const fetchXcmBalance = async ({
   }
 };
 
+const calRelaychainMinBal = (existentialDeposit: number): number => {
+  // Memo: hardcode it because ED for KSM is too small
+  const ksmMinBal = 0.0001;
+  const minBal = existentialDeposit * 1.1;
+
+  if (existentialDeposit > ksmMinBal) {
+    return minBal;
+  } else {
+    return ksmMinBal;
+  }
+};
+
 export const fetchExistentialDeposit = async (api: ApiPromise): Promise<ExistentialDeposit> => {
   const amount = api.consts.balances.existentialDeposit.toString();
 
@@ -65,11 +77,14 @@ export const fetchExistentialDeposit = async (api: ApiPromise): Promise<Existent
   const formattedProperties = properties.toHuman() as any;
   const decimals = formattedProperties.tokenDecimals[0] as string;
   const symbol = formattedProperties.tokenSymbol[0] as string;
+  const existentialDeposit = Number(ethers.utils.formatUnits(amount, decimals)).toFixed(7);
+  const relaychainMinBal = calRelaychainMinBal(Number(existentialDeposit));
 
   const data = {
-    amount: Number(ethers.utils.formatUnits(amount, decimals)).toFixed(7),
+    amount: existentialDeposit,
     symbol,
     chain: chain.toString(),
+    relaychainMinBal,
   };
 
   return data;


### PR DESCRIPTION
**Pull Request Summary**
* feat: leaving safe amount (existential deposit * 1.1) in relaychain after XCM transfer
  * ticket: https://www.notion.so/astarnetwork/a5eb9f984d7747a8bad9589fa557dad3?v=d3fc363160a94f66af95f07fc86d6b04&p=06f73d0ab0294e3d84fe5111ad86c264   

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

Relaychain Balance - amount (1.401 - 0.3) > ED * 1.1 (1.1 for DOT) 
![Screenshot 2022-06-07 at 4 57 03 PM](https://user-images.githubusercontent.com/92044428/172348035-79114eb4-42df-47b0-817e-b80c7a358872.png)

![Screenshot 2022-06-07 at 4 57 21 PM](https://user-images.githubusercontent.com/92044428/172348076-4505d750-ccb1-4ea3-8487-0f9013723a94.png)

![Screenshot 2022-06-07 at 4 56 03 PM](https://user-images.githubusercontent.com/92044428/172348151-56bad165-e26e-4a45-ada1-ce7f504443e5.png)
