### PR TITLE
fix: avoid calling unnecessary `watchers` way too much after `hot reloading`

### DIFF
--- a/src/hooks/custom-signature/useEvmAccount.ts
+++ b/src/hooks/custom-signature/useEvmAccount.ts
@@ -56,8 +56,11 @@ export function useEvmAccount() {
 
       // unsubscribe / prevent memory leak
       registerCleanup(() => {
-        provider.removeListener('accountsChanged', handleAccountsChanged);
-        provider.removeListener('chainChanged', handleChainChanged);
+        // Memo: this block calls a lot of `watchs` / `watchEffects` way too much after hot-reload
+        if (!process.env.DEV) {
+          provider.removeListener('accountsChanged', handleAccountsChanged);
+          provider.removeListener('chainChanged', handleChainChanged);
+        }
       });
     }
   };

--- a/src/hooks/custom-signature/useEvmAccount.ts
+++ b/src/hooks/custom-signature/useEvmAccount.ts
@@ -56,7 +56,7 @@ export function useEvmAccount() {
 
       // unsubscribe / prevent memory leak
       registerCleanup(() => {
-        // Memo: this block calls a lot of `watchs` / `watchEffects` way too much after hot-reload
+        // Memo: this block calls a lot of `watchs` / `watchEffects` (that outside of this file) way too much after hot reloading
         if (!process.env.DEV) {
           provider.removeListener('accountsChanged', handleAccountsChanged);
           provider.removeListener('chainChanged', handleChainChanged);


### PR DESCRIPTION
**Pull Request Summary**

* fix: avoid calling the EVM wallet's `eventListener`(removeListener) in development mode
  * fix: avoid falling into infinite loop after hot reloading 
  * ref: `removeListener` was added in this PR. https://github.com/AstarNetwork/astar-apps/pull/450 CC:  @pedroapfilho  @0xKheops 

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**

=Before=
It causes a lot of errors such as `Invalid JSON RPC response` after hot reloading because watchers keep connecting to the RPC server like an infinite loop. 

![image](https://user-images.githubusercontent.com/92044428/175467278-2d7d0fbc-6500-4991-bbfd-4e17c1285ecc.png)



