### PR TITLE
fix: get XCM assets in H160 mode

### DIFF
--- a/src/components/assets/Assets.vue
+++ b/src/components/assets/Assets.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="selectedAddress && isDisplay" class="wrapper--assets">
+  <div v-if="currentAccount && isDisplay" class="wrapper--assets">
     <div class="container--assets">
       <Account
         :ttl-erc20-amount="ttlErc20Amount"
@@ -7,7 +7,7 @@
         :is-loading-erc20-amount="isLoadingErc20Amount"
         :is-loading-xcm-assets-amount="isLoadingXcmAssetsAmount"
       />
-      <div v-if="selectedAddress">
+      <div v-if="currentAccount">
         <div v-if="isH160">
           <EvmAssetList
             :tokens="tokens"
@@ -53,7 +53,7 @@ import NativeAssetList from 'src/components/assets/NativeAssetList.vue';
 import XcmNativeAssetList from 'src/components/assets/XcmNativeAssetList.vue';
 import { endpointKey, getProviderIndex } from 'src/config/chainEndpoints';
 import { LOCAL_STORAGE } from 'src/config/localStorage';
-import { ChainAsset, useBalance, useCbridgeV2, useXcmAssets } from 'src/hooks';
+import { ChainAsset, useAccount, useBalance, useCbridgeV2, useXcmAssets } from 'src/hooks';
 import { wait } from 'src/hooks/helper/common';
 import { useStore } from 'src/store';
 import { computed, defineComponent, ref, watch, watchEffect } from 'vue';
@@ -83,8 +83,8 @@ export default defineComponent({
       handleUpdateTokenBalances: handleUpdateXcmTokenBalances,
     } = useXcmAssets();
     const store = useStore();
-    const selectedAddress = computed(() => store.getters['general/selectedAddress']);
-    const { accountData } = useBalance(selectedAddress);
+    const { currentAccount } = useAccount();
+    const { accountData } = useBalance(currentAccount);
     const isH160 = computed(() => store.getters['general/isH160Formatted']);
     const currentNetworkIdx = computed(() => {
       const chainInfo = store.getters['general/chainInfo'];
@@ -98,13 +98,10 @@ export default defineComponent({
     const xcmAssets = computed(() => store.getters['assets/getAllAssets']);
 
     watch(
-      selectedAddress,
+      currentAccount,
       (newValue) => {
-        // TODO investigate why when we use metamask and sett asset to vuex, address is changed in store for some reason
-        // and wathcer is called again, whiche ends in infinite loop.
-        if (newValue && (!isH160.value || (isH160.value && newValue !== selectedAddress.value))) {
-          store.dispatch('assets/getAssets', newValue);
-        }
+        if (!newValue) return;
+        store.dispatch('assets/getAssets', newValue);
       },
       { immediate: true }
     );
@@ -165,7 +162,7 @@ export default defineComponent({
     return {
       isLoadingErc20Amount,
       isLoadingXcmAssetsAmount,
-      selectedAddress,
+      currentAccount,
       isH160,
       tokens,
       ttlErc20Amount,


### PR DESCRIPTION
**Pull Request Summary**

* fix: get `XCM assets` in H160 mode

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**


**Fixes**
- (ex: Fix validation function)

=Before=
This value returns an empty array in H160 mode.
![image](https://user-images.githubusercontent.com/92044428/178948209-85193199-a063-4366-b622-510cd5f229a0.png)

=After=
<img width="1645" alt="image" src="https://user-images.githubusercontent.com/92044428/178948515-04f79310-810a-4f75-b116-0cfeced14b10.png">
