### PR TITLE
fix: typo in ModalVesting

### DIFF
--- a/src/components/assets/modals/ModalVesting.vue
+++ b/src/components/assets/modals/ModalVesting.vue
@@ -36,10 +36,10 @@
       </div>
       <div class="box--unlock-amount">
         <div class="box__column-amount">
-          <span class="text--accent">{{ $t('assets.modals.availableToUnlocked') }}</span>
+          <span class="text--accent">{{ $t('assets.modals.availableToUnlock') }}</span>
           <span class="text--xl"
-            >{{ $n(truncate(info.claimableAmount)) }} {{ nativeTokenSymbol }}</span
-          >
+            >{{ $n(truncate(info.claimableAmount)) }} {{ nativeTokenSymbol }}
+          </span>
         </div>
       </div>
       <SpeedConfiguration

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -5,6 +5,7 @@ import {
   SubstrateWallets,
   supportEvmWalletObj,
   SupportWallet,
+  supportWalletObj,
   WalletModalOption,
 } from 'src/config/wallets';
 import { getChainId, setupNetwork } from 'src/config/web3';
@@ -197,7 +198,11 @@ export const useConnectWallet = () => {
       watchPostEffect(async () => {
         store.commit('general/setMetaExtensions', metaExtensions.value);
         store.commit('general/setExtensionCount', extensionCount.value);
-        // setWallet(wallet);
+        const isSubstrateWallet = supportWalletObj.hasOwnProperty(wallet);
+        // Memo: displays accounts menu for users who use the portal first time
+        if (isSubstrateWallet) {
+          setWallet(wallet);
+        }
       });
     }
   };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -303,7 +303,7 @@ export default {
       alreadyVested: 'Already vested',
       remainingVests: 'Remaining vests',
       unlockPerBlock: '{perToken} {symbol} per block until block {untilBlock}',
-      availableToUnlocked: 'Available to unlock',
+      availableToUnlock: 'Available to unlock',
       unlock: 'Unlock',
       transfer: 'Transfer',
       evmXcmDeposit: 'EVM (Deposit)',

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -303,7 +303,7 @@ export default {
       alreadyVested: 'Already vested',
       remainingVests: 'Remaining vests',
       unlockPerBlock: '{perToken} {symbol} per block until block {untilBlock}',
-      availableToUnlocked: 'Available to unlocked',
+      availableToUnlocked: 'Available to unlock',
       unlock: 'Unlock',
       transfer: 'Transfer',
       evmXcmDeposit: 'EVM (Deposit)',


### PR DESCRIPTION
**Pull Request Summary**

* fix: typo in ModalVesting
* fix: displays accounts menu for users who visit the portal first time 

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**


**Fixes**

=Before=
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92044428/179873408-980f1c8d-8e3e-4051-8178-35a22c26dd23.png">


=After=
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92044428/179875441-d244e96d-ca15-419c-b050-b5b52b4e7f89.png">


* fix: displays accounts menu for users who visit the portal first time (after approving portal to access substrate wallets extension)
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92044428/179875357-7caf1c63-11dc-4cb7-b1c1-55dd7987e70f.png">
