### PR TITLE
Incorrect unbonding amount displayed fix

### DIFF
--- a/src/components/dapp-staking/StakePanel.vue
+++ b/src/components/dapp-staking/StakePanel.vue
@@ -251,7 +251,8 @@ export default defineComponent({
 
     const unstake = async (stakeData: StakeModel): Promise<void> => {
       const amount = getAmount(stakeData.amount, stakeData.unit);
-      const unstakeAmount = plasmUtils.balanceFormatter(amount);
+      const amountActual = getAmount(stakeData.unbondedActual, stakeData.unit);
+      const unstakeAmount = plasmUtils.balanceFormatter(amountActual);
       try {
         const transaction = canUnbondWithdraw.value
           ? $api!.tx.dappsStaking.unbondAndUnstake(getAddressEnum(props.dapp.address), amount)

--- a/src/components/dapp-staking/modals/StakeModal.vue
+++ b/src/components/dapp-staking/modals/StakeModal.vue
@@ -71,6 +71,9 @@
       >
         {{ $t('dappStaking.maxChunksWarning', { chunks: maxUnlockingChunks }) }}
       </div>
+      <div v-if="actionName === StakeAction.Unstake" class="box__row--err-msg">
+        <span>{{ minUnbondingInfo }}</span>
+      </div>
       <div class="container--speed-configuration">
         <SpeedConfiguration
           :is-responsible="true"
@@ -112,7 +115,7 @@ import { $api } from 'boot/api';
 import * as plasmUtils from 'src/hooks/helper/plasmUtils';
 import { getAmount, StakeModel } from 'src/hooks/store';
 import { useStore } from 'src/store';
-import { computed, defineComponent, ref, toRefs, PropType, watchEffect } from 'vue';
+import { computed, defineComponent, ref, toRefs, PropType, watch } from 'vue';
 import { StakeAction } from '../StakePanel.vue';
 import ModalNominationTransfer from 'src/components/dapp-staking/modals/ModalNominationTransfer.vue';
 import { StakingData } from 'src/modules/dapp-staking';
@@ -341,6 +344,38 @@ export default defineComponent({
       isEnableNominationTransfer.value ? setSelectedTipNominationTransfer : props.setSelectedTip
     );
 
+    const isFullUnbonding = () => {
+      const inputAmount = Number(data.value.amount);
+
+      if (inputAmount && props.actionName == StakeAction.Unstake) {
+        const amount = Number(ethers.utils.formatEther(props.stakeAmount.toString()));
+        return amount > inputAmount && amount - inputAmount < formattedMinStaking.value;
+      }
+
+      return false;
+    };
+
+    const minUnbondingInfo = computed(() => {
+      if (isFullUnbonding()) {
+        return t('dappStaking.error.allFundsWillBeUnbonded', {
+          minStakingAmount: formattedMinStaking.value,
+          symbol: nativeTokenSymbol.value,
+        });
+      }
+
+      return '';
+    });
+
+    watch(
+      [data],
+      () => {
+        data.value.unbondedActual = isFullUnbonding()
+          ? Number(ethers.utils.formatEther(props.stakeAmount.toString()))
+          : data.value.amount;
+      },
+      { deep: true }
+    );
+
     return {
       data,
       formatStakeAmount,
@@ -359,6 +394,7 @@ export default defineComponent({
       addressTransferFrom,
       handleNominationTransfer,
       isDisabledNominationTransfer,
+      minUnbondingInfo,
       nominationTransferMaxAmount,
       isEnableNominationTransfer: isEnableNominationTransfer.value,
       errMsg,

--- a/src/hooks/store/index.ts
+++ b/src/hooks/store/index.ts
@@ -8,6 +8,7 @@ export interface StakeModel {
   amount: number;
   unit: string;
   decimal: number;
+  unbondedActual: number;
 }
 
 export const getAmount = (amount: number, unit: string): BN => {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -212,6 +212,8 @@ export default {
         'The amount of token to be staking must be greater than {amount} {symbol}',
       allFundsWillBeTransferred:
         'All funds will be transferred because the min. staking amount is {minStakingAmount} {symbol}',
+      allFundsWillBeUnbonded:
+        'All funds will be unbonded because the min. staking amount is {minStakingAmount} {symbol}',
     },
   },
   bridge: {


### PR DESCRIPTION
**Pull Request Summary**

Fix for issue #284 

Changed un-bonding dialog to show warning if all funds will be un-bonded
![image](https://user-images.githubusercontent.com/8452361/181204506-54751640-3cf1-44a7-ae6e-8e9095fa05a9.png)

Display actually un-bonded amount in popup
![image](https://user-images.githubusercontent.com/8452361/181205153-33de8a22-1ed9-468c-b3cc-c9811f48134d.png)
Although user entered 4 SBY, 6 SBY are actually un-bonded 

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**
- Fixed un-bonded amount display 

Closes #284 
