### PR TITLE
feat: enabled EVM withdrawal for Acala tokens

### DIFF
--- a/src/components/assets/Erc20Currency.vue
+++ b/src/components/assets/Erc20Currency.vue
@@ -152,16 +152,9 @@ export default defineComponent({
     });
 
     const isDisabledXcmButton = computed(() => {
-      const chainInfo = store.getters['general/chainInfo'];
-      const chain = chainInfo ? chainInfo.chain : '';
-      const currentNetworkIdx = getProviderIndex(chain);
-
       // Memo: Remove after runtime upgrading in shinde
       const isMovr = token.symbol === MOVR.symbol;
-      // Memo: Remove after runtime upgrading in astar network to enable EVM withdrawal
-      const isAstar = currentNetworkIdx === endpointKey.ASTAR;
-
-      return (isAstar && token.symbol !== 'DOT') || isMovr;
+      return isMovr;
     });
 
     const isImportedToken = computed<boolean>(

--- a/src/components/assets/modals/ModalXcmBridge.vue
+++ b/src/components/assets/modals/ModalXcmBridge.vue
@@ -180,6 +180,14 @@
             </span>
           </div>
         </div>
+        <div class="row--warning">
+          <div class="column--title">
+            <span class="text--dot">・</span>
+            <span class="text--warning">
+              {{ $t('assets.modals.xcmWarning.notInputExchanges') }}
+            </span>
+          </div>
+        </div>
       </div>
       <div v-if="errMsg" class="row--box-error">
         <span class="color--white"> {{ $t(errMsg) }}</span>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -322,7 +322,7 @@ export default {
       xcmWarning: {
         minBalIsRequired: 'Min. balance is required on origin chain',
         fee: 'Fee is deducted from the amount entered',
-        notInputExchanges: "Please don't input exchanges wallet address",
+        notInputExchanges: 'Do not input wallet address of exchanges',
         tooltip:
           'We keep {amount} {symbol} in origin chain account to avoid losing the funds (existential deposit). When depositing from origin chain, only tokens that are above the minimum balance are transferable. When withdrawing the receiver origin chain must have more than {amount} {symbol}.',
         nonzeroBalance: 'the balance of recipient account should be above zero',

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -322,6 +322,7 @@ export default {
       xcmWarning: {
         minBalIsRequired: 'Min. balance is required on origin chain',
         fee: 'Fee is deducted from the amount entered',
+        notInputExchanges: "Please don't input exchanges wallet address",
         tooltip:
           'We keep {amount} {symbol} in origin chain account to avoid losing the funds (existential deposit). When depositing from origin chain, only tokens that are above the minimum balance are transferable. When withdrawing the receiver origin chain must have more than {amount} {symbol}.',
         nonzeroBalance: 'the balance of recipient account should be above zero',


### PR DESCRIPTION
**Pull Request Summary**

* feat: enabled EVM withdrawal for Acala tokens.  [Ref](https://stakesg.slack.com/archives/C03BN19LBQ8/p1658136783723779?thread_ts=1656938315.093039&cid=C03BN19LBQ8)
    * Memo: EVM withdrawal for MOVR will be enabled after 11th Aug. [Ref](https://stakesg.slack.com/archives/C03BN19LBQ8/p1659955657211789?thread_ts=1656938315.093039&cid=C03BN19LBQ8) 
* fix: added a warning message on the XCM modal [Ref](https://stakesg.slack.com/archives/C028H2ZSGRK/p1659890530632729)

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Adds**
* fix: added a warning message on the XCM modal

<img  width="450" src="https://user-images.githubusercontent.com/92044428/183399808-16713ed5-206d-4a3c-9df5-82a29ed534ed.png" />

