### PR TITLE
fix: modified ED check in EVM withdrawal for XCM assets

### DIFF
--- a/src/components/assets/modals/ModalXcmBridge.vue
+++ b/src/components/assets/modals/ModalXcmBridge.vue
@@ -194,7 +194,6 @@
       </div>
       <div class="wrapper__row--button">
         <button class="btn btn--confirm" :disabled="isDisabledBridge" @click="handleBridge">
-          <!-- <button class="btn btn--confirm" @click="handleBridge"> -->
           {{ $t('confirm') }}
         </button>
       </div>

--- a/src/components/assets/modals/ModalXcmBridge.vue
+++ b/src/components/assets/modals/ModalXcmBridge.vue
@@ -193,7 +193,8 @@
         <span class="color--white"> {{ $t(errMsg) }}</span>
       </div>
       <div class="wrapper__row--button">
-        <button class="btn btn--confirm" :disabled="isDisabledBridge" @click="handleBridge">
+        <!-- <button class="btn btn--confirm" :disabled="isDisabledBridge" @click="handleBridge"> -->
+        <button class="btn btn--confirm" @click="handleBridge">
           {{ $t('confirm') }}
         </button>
       </div>

--- a/src/components/assets/modals/ModalXcmBridge.vue
+++ b/src/components/assets/modals/ModalXcmBridge.vue
@@ -193,8 +193,8 @@
         <span class="color--white"> {{ $t(errMsg) }}</span>
       </div>
       <div class="wrapper__row--button">
-        <!-- <button class="btn btn--confirm" :disabled="isDisabledBridge" @click="handleBridge"> -->
-        <button class="btn btn--confirm" @click="handleBridge">
+        <button class="btn btn--confirm" :disabled="isDisabledBridge" @click="handleBridge">
+          <!-- <button class="btn btn--confirm" @click="handleBridge"> -->
           {{ $t('confirm') }}
         </button>
       </div>

--- a/src/hooks/xcm/SubstrateApi.ts
+++ b/src/hooks/xcm/SubstrateApi.ts
@@ -378,7 +378,9 @@ export class AstarApi extends BaseApi {
           },
         };
 
-    const isAccountId20 = paraId === parachainIds.MOONBEAM || paraId === parachainIds.MOONRIVER;
+    // Todo: un-comment-out after channel between Astar and Moonbeam has been opened
+    // const isAccountId20 = paraId === parachainIds.MOONBEAM || paraId === parachainIds.MOONRIVER;
+    const isAccountId20 = paraId === parachainIds.MOONRIVER;
     const X1 = isAccountId20
       ? {
           AccountKey20: {

--- a/src/hooks/xcm/useXcmBridge.ts
+++ b/src/hooks/xcm/useXcmBridge.ts
@@ -31,7 +31,6 @@ import { isValidAddressPolkadotAddress } from './../helper/plasmUtils';
 import { AcalaApi, MoonbeamApi } from './parachainApi';
 import { MOONBEAM_ASTAR_TOKEN_ID } from './parachainApi/MoonbeamApi';
 import { AstarApi, AstarToken, ChainApi } from './SubstrateApi';
-import { wait } from '../helper/common';
 
 const { Acala, Astar, Karura, Moonriver, Polkadot, Shiden, Kusama } = xcmChainObj;
 
@@ -103,11 +102,15 @@ export function useXcmBridge(selectedToken: Ref<Asset>) {
   );
 
   const isMoonbeamWithdrawal = computed<boolean>(() => {
-    return destChain.value.name === Chain.MOONRIVER || destChain.value.name === Chain.MOONBEAM;
+    // Todo: un-comment-out after channel between Astar and Moonbeam has been opened
+    // return destChain.value.name === Chain.MOONRIVER || destChain.value.name === Chain.MOONBEAM;
+    return destChain.value.name === Chain.MOONRIVER;
   });
 
   const isMoonbeamDeposit = computed<boolean>(() => {
-    return srcChain.value.name === Chain.MOONRIVER || srcChain.value.name === Chain.MOONBEAM;
+    // Todo: un-comment-out after channel between Astar and Moonbeam has been opened
+    // return srcChain.value.name === Chain.MOONRIVER || srcChain.value.name === Chain.MOONBEAM;
+    return srcChain.value.name === Chain.MOONRIVER;
   });
 
   const { handleResult, handleTransactionError } = useCustomSignature({});

--- a/src/hooks/xcm/useXcmBridge.ts
+++ b/src/hooks/xcm/useXcmBridge.ts
@@ -205,10 +205,18 @@ export function useXcmBridge(selectedToken: Ref<Asset>) {
       ? await fetchMoonbeamNativeBal()
       : originChainNativeBal.value;
 
-    const originChainNativeBalance = isH160.value
-      ? evmDestAddressBalance.value
-      : fromOriginChainNativeBal;
-
+    let originChainNativeBalance = 0;
+    if (isH160.value) {
+      // Memo: withdraw mode
+      const destNativeBal = await originChainApi?.getNativeBalance(evmDestAddress.value);
+      const formattedNativeBal = (destNativeBal || '0').toString();
+      const nativeTokenDecimals = originChainApi?.chainProperty?.tokenDecimals[0];
+      originChainNativeBalance = Number(
+        ethers.utils.formatUnits(formattedNativeBal, nativeTokenDecimals)
+      );
+    } else {
+      originChainNativeBalance = fromOriginChainNativeBal;
+    }
     const isCountSendingAmount =
       isDeposit.value && selectedToken.value && selectedToken.value.isNativeToken;
     const sendingAmount = isCountSendingAmount ? amount : 0;
@@ -353,7 +361,7 @@ export function useXcmBridge(selectedToken: Ref<Asset>) {
   const setEvmDestAddressBalance = async (): Promise<void> => {
     if (!isLoadOriginApi.value) return;
     const address = evmDestAddress.value;
-    if (isH160.value) {
+    if (isH160.value && address) {
       if (!originChainApi) {
         evmDestAddressBalance.value = 0;
         return;

--- a/src/modules/xcm/index.ts
+++ b/src/modules/xcm/index.ts
@@ -17,7 +17,6 @@ export interface XcmTokenInformation {
   logo: string;
   isNativeToken: boolean;
   isXcmCompatible: boolean;
-  parachains?: string[];
   originAssetId: string;
   originChain: string;
   minBridgeAmount: string;

--- a/src/modules/xcm/index.ts
+++ b/src/modules/xcm/index.ts
@@ -39,7 +39,7 @@ export enum Chain {
   KARURA = 'Karura',
   ACALA = 'Acala',
   MOONRIVER = 'Moonriver',
-  MOONBEAM = 'Moonbeam',
+  // MOONBEAM = 'Moonbeam',
 }
 
 export enum parachainIds {
@@ -48,7 +48,7 @@ export enum parachainIds {
   KARURA = 2000,
   ACALA = 2000,
   MOONRIVER = 2023,
-  MOONBEAM = 2004,
+  // MOONBEAM = 2004,
 }
 
 // Memo: give it 0 ide for convenience in checking para/relay chain logic
@@ -114,13 +114,14 @@ export const xcmChainObj: XcmChainObj = {
     parachainId: parachainIds.MOONRIVER,
     endpoint: 'wss://wss.api.moonriver.moonbeam.network',
   },
-  [Chain.MOONBEAM]: {
-    name: Chain.MOONBEAM,
-    relayChain: Chain.POLKADOT,
-    img: 'https://polkadot.js.org/apps/static/moonbeam.3204d901..png',
-    parachainId: parachainIds.MOONBEAM,
-    endpoint: 'wss://wss.api.moonbeam.network',
-  },
+  // Todo: un-comment-out after channel between Astar and Moonbeam has been opened
+  // [Chain.MOONBEAM]: {
+  //   name: Chain.MOONBEAM,
+  //   relayChain: Chain.POLKADOT,
+  //   img: 'https://polkadot.js.org/apps/static/moonbeam.3204d901..png',
+  //   parachainId: parachainIds.MOONBEAM,
+  //   endpoint: 'wss://wss.api.moonbeam.network',
+  // },
 };
 
 const xcmChains = objToArray(xcmChainObj);

--- a/src/modules/xcm/tokens/index.ts
+++ b/src/modules/xcm/tokens/index.ts
@@ -5,6 +5,10 @@ import { ASTAR_DECIMALS } from 'src/hooks/helper/plasmUtils';
 // Acala Note: There is no endpoint to get minBridgeAmount.  But the rule is that Acala doesn't allow transfers that are less value than the equivalent of $0.01USD
 // Ref: https://www.notion.so/astarnetwork/HRMP-Portal-Support-for-Acala-Karura-UI-2eaab2e1d93c4e0f90609ea7039942a9#5c5a40f95c7b4c93a201feef233cb0fa
 
+// Acala Note: minBridgeAmount should be more than ED
+// Ref: https://wiki.acala.network/get-started/acala-network/acala-account
+// Ref: https://wiki.acala.network/get-started/get-started/karura-account
+
 export const xcmToken = {
   [endpointKey.ASTAR]: [
     {
@@ -45,7 +49,7 @@ export const xcmToken = {
       logo: 'https://assets.coingecko.com/coins/images/25812/small/ezgif-1-f4612f5260.png?1653987299',
       isXcmCompatible: true,
       originChain: 'Acala',
-      minBridgeAmount: '0.0193',
+      minBridgeAmount: '0.11',
     },
   ],
   [endpointKey.SHIDEN]: [
@@ -67,7 +71,7 @@ export const xcmToken = {
       logo: 'https://assets.coingecko.com/coins/images/25812/small/ezgif-1-f4612f5260.png?1653987299',
       isXcmCompatible: true,
       originChain: 'Karura',
-      minBridgeAmount: '0.0193',
+      minBridgeAmount: '0.11',
     },
     {
       symbol: 'KAR',
@@ -77,7 +81,7 @@ export const xcmToken = {
       logo: 'https://assets.coingecko.com/coins/images/17172/small/karura.jpeg?1626782066',
       isXcmCompatible: true,
       originChain: 'Karura',
-      minBridgeAmount: '0.004948',
+      minBridgeAmount: '0.11',
     },
     {
       symbol: 'LKSM',
@@ -153,7 +157,6 @@ export const SDN: XcmTokenInformation = {
   isXcmCompatible: true,
   originChain: 'Shiden',
   minBridgeAmount: '0.1',
-  parachains: ['Karura'],
 };
 
 export const ASTR: XcmTokenInformation = {
@@ -165,7 +168,6 @@ export const ASTR: XcmTokenInformation = {
   isXcmCompatible: true,
   originChain: 'Astar',
   minBridgeAmount: '0.1',
-  parachains: ['Acala'],
 };
 
 export const SBY: XcmTokenInformation = {
@@ -177,7 +179,6 @@ export const SBY: XcmTokenInformation = {
   isXcmCompatible: true,
   originChain: 'Shibuya',
   minBridgeAmount: '0.1',
-  parachains: [''],
 };
 
 export const xcmAstarNativeToken = { SDN, ASTR, SBY };


### PR DESCRIPTION
**Pull Request Summary**

* fix: modified ED check (native token balance in origin chain) for EVM withdrawal for XCM assets
* fix: updated `minBridgeAmount` for AUSD and KAR token because the amount should be more than ED (Acala tokens have ED in each XCM assets )
  *  ref: https://wiki.acala.network/get-started/acala-network/acala-account 
* fix: removed `MOONBEAM` option from XCM transfer UI in ASTR

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**


**Fixes**
* fix: modified ED check (native token balance in origin chain) for EVM withdrawal for XCM assets

Account's native token balance: [0.2ACA](https://acala.subscan.io/account/24Y913oKBCBpPP3q8RLbDCBoZMxneU5VSnWHHkYVRH2cEnvq) 

=Before=
<img width="400"  src="https://user-images.githubusercontent.com/92044428/184332260-7fd66297-103e-4907-9e25-f0f157c2d956.png">

=After=
<img width="400"  src="https://user-images.githubusercontent.com/92044428/184331845-2624334d-1358-47f6-a331-0027b7354894.png">

* fix: removed `MOONBEAM` option from XCM transfer UI in ASTR
=Before=
<img width="400"  src="https://user-images.githubusercontent.com/92044428/184332449-4a9b8852-9ded-4c0d-acce-e2506a4e4fd0.png">

=After=
<img width="400"  src="https://user-images.githubusercontent.com/92044428/184332595-2d13ab32-08c4-4818-95a1-5b3987fd0c27.png">
