### PR TITLE
fix: modified parsing amount logic for the native currencies

### DIFF
--- a/src/components/common/Modal.vue
+++ b/src/components/common/Modal.vue
@@ -1,47 +1,48 @@
 <template>
-  <div class="tw-fixed tw-z-10 tw-inset-0 tw-overflow-y-auto" @click="closeModal()">
-    <div class="tw-flex tw-items-center tw-justify-center tw-min-h-screen">
-      <!-- Background overlay -->
-      <div class="tw-fixed tw-inset-0 tw-transition-opacity" aria-hidden="true">
-        <div class="tw-absolute tw-inset-0 tw-bg-gray-900 dark:tw-bg-black tw-opacity-75"></div>
-      </div>
+  <Teleport to="#app--main">
+    <div class="tw-fixed tw-inset-0 tw-overflow-y-auto highest-z-index" @click="closeModal()">
+      <div class="tw-flex tw-items-center tw-justify-center tw-min-h-screen">
+        <!-- Background overlay -->
+        <div class="tw-fixed tw-inset-0 tw-transition-opacity" aria-hidden="true">
+          <div class="tw-absolute tw-inset-0 tw-bg-gray-900 dark:tw-bg-black tw-opacity-75"></div>
+        </div>
 
-      <div
-        class="
-          tw-inline-block tw-bg-white
-          dark:tw-bg-darkGray-900
-          tw-rounded-lg tw-px-4
-          sm:tw-px-8
-          tw-py-10
-          tw-shadow-xl
-          tw-transform
-          tw-transition-all
-          tw-mx-2
-          tw-my-2
-          tw-align-middle
-          tw-w-auto
-        "
-        @click.stop
-      >
-        <div>
+        <div
+          class="
+            tw-inline-block tw-bg-white
+            dark:tw-bg-darkGray-900
+            tw-rounded-lg tw-px-4
+            sm:tw-px-8
+            tw-py-10
+            tw-shadow-xl
+            tw-transform
+            tw-transition-all
+            tw-mx-2
+            tw-my-2
+            tw-align-middle
+            tw-w-auto
+          "
+        >
           <div>
-            <h3
-              class="
-                tw-text-lg tw-font-extrabold tw-text-blue-900
-                dark:tw-text-white
-                tw-mb-6 tw-text-center
-              "
-            >
-              {{ title }}
-            </h3>
             <div>
-              <slot name="content"></slot>
+              <h3
+                class="
+                  tw-text-lg tw-font-extrabold tw-text-blue-900
+                  dark:tw-text-white
+                  tw-mb-6 tw-text-center
+                "
+              >
+                {{ title }}
+              </h3>
+              <div>
+                <slot name="content"></slot>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script lang="ts">

--- a/src/components/dapp-staking/StakePanel.vue
+++ b/src/components/dapp-staking/StakePanel.vue
@@ -92,7 +92,7 @@ import { useChainMetadata, useCustomSignature, useGasPrice, useGetMinStaking } f
 import { TxType } from 'src/hooks/custom-signature/message';
 import * as plasmUtils from 'src/hooks/helper/plasmUtils';
 import { signAndSend } from 'src/hooks/helper/wallet';
-import { getAmount, StakeModel } from 'src/hooks/store';
+import { StakeModel } from 'src/hooks/store';
 import { useUnbondWithdraw } from 'src/hooks/useUnbondWithdraw';
 import { StakingData } from 'src/modules/dapp-staking';
 import { useStore } from 'src/store';
@@ -195,7 +195,7 @@ export default defineComponent({
     });
 
     const stake = async (stakeData: StakeModel): Promise<void> => {
-      const amount = getAmount(stakeData.amount, stakeData.unit);
+      const amount = plasmUtils.parseTo18Decimals(stakeData.amount);
       const unit = stakeData.unit;
       try {
         const stakeAmount = plasmUtils.balanceFormatter(amount);
@@ -250,8 +250,8 @@ export default defineComponent({
     };
 
     const unstake = async (stakeData: StakeModel): Promise<void> => {
-      const amount = getAmount(stakeData.amount, stakeData.unit);
-      const amountActual = getAmount(stakeData.unbondedActual, stakeData.unit);
+      const amount = plasmUtils.parseTo18Decimals(stakeData.amount);
+      const amountActual = plasmUtils.parseTo18Decimals(stakeData.unbondedActual);
       const unstakeAmount = plasmUtils.balanceFormatter(amountActual);
       try {
         const transaction = canUnbondWithdraw.value

--- a/src/components/dapp-staking/modals/StakeModal.vue
+++ b/src/components/dapp-staking/modals/StakeModal.vue
@@ -113,7 +113,7 @@ import InputAmount from 'src/components/common/InputAmount.vue';
 import { useChainMetadata, useNominationTransfer, useUnbondWithdraw } from 'src/hooks';
 import { $api } from 'boot/api';
 import * as plasmUtils from 'src/hooks/helper/plasmUtils';
-import { getAmount, StakeModel } from 'src/hooks/store';
+import { StakeModel } from 'src/hooks/store';
 import { useStore } from 'src/store';
 import { computed, defineComponent, ref, toRefs, PropType, watch } from 'vue';
 import { StakeAction } from '../StakePanel.vue';
@@ -243,7 +243,7 @@ export default defineComponent({
 
     const canExecuteAction = computed(() => {
       if (data.value) {
-        const amount = getAmount(data.value.amount, data.value.unit);
+        const amount = plasmUtils.parseTo18Decimals(data.value.amount);
         const useableStakeAmount = props.accountData.getUsableFeeBalance();
 
         let canExecute =

--- a/src/hooks/helper/plasmUtils.ts
+++ b/src/hooks/helper/plasmUtils.ts
@@ -2,6 +2,7 @@ import { BigNumber, formatFixed } from '@ethersproject/bignumber';
 import { hexToU8a, isHex, isString } from '@polkadot/util';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 import BN from 'bn.js';
+import { ethers } from 'ethers';
 import { LOCAL_STORAGE } from './../../config/localStorage';
 import { nFormatter } from './units';
 
@@ -67,32 +68,13 @@ export const defaultAmountWithDecimals = (
   }
 };
 
-export const reduceDenomToBalance = (bal: number, unit: number, decimal: number) => {
-  const unit_decimal = unit + decimal;
-  const decPoint = new BN(10).pow(new BN(unit_decimal));
-  // console.log('d', decPoint.toString())
-
-  const strBal = bal.toString();
-  // console.log('b', bal.toString())
-
-  let formatted = new BN(0);
-
-  const arrDecimalBal = strBal.split('.');
-  if (arrDecimalBal.length === 2) {
-    const intBal = arrDecimalBal[0];
-    const minorityBal = arrDecimalBal[1];
-    const remainNum = Number(`${intBal}${minorityBal}`);
-    const decimalLength = minorityBal.length;
-    // console.log('intBal', intBal)
-    // console.log('minorityBal', minorityBal)
-    // console.log('decimalLength', decimalLength)
-    const divPoint = new BN(10).pow(new BN(decimalLength));
-    formatted = decPoint.mul(new BN(remainNum)).div(divPoint);
-  } else {
-    formatted = decPoint.mul(new BN(bal));
-  }
-  // console.log('f', formatted.toString())
-  return formatted;
+/**
+ * Convert the given value into the 18 decimals amount.
+ * @param amount 0.1
+ * @returns '100000000000000000' (format: BN)
+ */
+export const parseTo18Decimals = (amount: number | string): BN => {
+  return new BN(ethers.utils.parseEther(String(amount)).toString());
 };
 
 export const isValidAddressPolkadotAddress = (address: string) => {

--- a/src/hooks/store/index.ts
+++ b/src/hooks/store/index.ts
@@ -1,8 +1,3 @@
-import BN from 'bn.js';
-import { getUnit } from 'src/hooks/helper/units';
-import { reduceDenomToBalance } from 'src/hooks/helper/plasmUtils';
-import { useChainMetadata } from 'src/hooks';
-
 export interface StakeModel {
   address: string;
   amount: number;
@@ -10,9 +5,3 @@ export interface StakeModel {
   decimal: number;
   unbondedActual: number;
 }
-
-export const getAmount = (amount: number, unit: string): BN => {
-  const unitIndex = getUnit(unit);
-  const { decimal } = useChainMetadata();
-  return reduceDenomToBalance(amount, unitIndex, decimal.value);
-};

--- a/src/hooks/transfer/useTransfer.ts
+++ b/src/hooks/transfer/useTransfer.ts
@@ -1,6 +1,5 @@
 import { useI18n } from 'vue-i18n';
 import { ISubmittableResult } from '@polkadot/types/types';
-import BN from 'bn.js';
 import { $api } from 'boot/api';
 import { ethers } from 'ethers';
 import ABI from 'src/c-bridge/abi/ERC20.json';
@@ -11,8 +10,7 @@ import {
   toSS58Address,
 } from 'src/config/web3';
 import { useCustomSignature } from 'src/hooks';
-import { isValidAddressPolkadotAddress, reduceDenomToBalance } from 'src/hooks/helper/plasmUtils';
-import { getUnit } from 'src/hooks/helper/units';
+import { isValidAddressPolkadotAddress } from 'src/hooks/helper/plasmUtils';
 import { getEvmGas } from 'src/modules/gas-api';
 import { useStore } from 'src/store';
 import { computed, Ref, ref } from 'vue';
@@ -50,7 +48,7 @@ export function useTransfer(selectUnit: Ref<string>, decimal: Ref<number>, fn?: 
     setSelectedTip,
   } = useGasPrice();
 
-  const transferNative = async (transferAmt: BN, fromAddress: string, toAddress: string) => {
+  const transferNative = async (transferAmt: string, fromAddress: string, toAddress: string) => {
     try {
       const txResHandler = async (result: ISubmittableResult): Promise<boolean> => {
         const res = await handleResult(result);
@@ -123,8 +121,7 @@ export function useTransfer(selectUnit: Ref<string>, decimal: Ref<number>, fn?: 
       }
 
       const receivingAddress = isValidEvmAddress(toAddress) ? toSS58Address(toAddress) : toAddress;
-      const unit = getUnit(selectUnit.value);
-      const toAmt = reduceDenomToBalance(transferAmt, unit, decimal.value);
+      const toAmt = ethers.utils.parseEther(String(transferAmt)).toString();
       await transferNative(toAmt, fromAddress, receivingAddress);
     }
   };


### PR DESCRIPTION
**Pull Request Summary**

* fix: modified parsing the amount logic (to 18 decimals)  for native currencies
  * background: some users raised an issue that the inputted amount cannot be parsed in the previous logic (an error occurred in [this line](https://github.com/AstarNetwork/astar-apps/pull/484/files#diff-7d03b3d5759663bb88b973c203ac29c7fbd54d7ed2c54da3e148304f4d999e41L90)), since I cannot reproduce the error, I've used the standard parsing function that is exported from the library to resolve the issue. Also, I reduced the "Decimals" parameter since the function is used only for the native currencies (decimals: 18).
  * ref: 
    * https://stakesg.slack.com/archives/C028H2ZSGRK/p1660521841022289
    * https://stakesg.slack.com/archives/C028H2ZSGRK/p1660274418396239 

* fix: modified an z-index issues in legacy modals
  * related to:  https://github.com/AstarNetwork/astar-apps/pull/477

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**
- (ex: Change document B)

* fix: modified an z-index issues in legacy modals

=Before=
<img src="https://user-images.githubusercontent.com/92044428/184579377-19f58261-cb14-4915-9540-397fb541b1e9.png" width="600" />

=After=
<img src="https://user-images.githubusercontent.com/92044428/184579395-9636839b-1a4b-4321-933a-50f690bb49a8.png" width="400" />
