### PR TITLE
Added parachain id as it is not default anymore

### DIFF
--- a/rpc-tests/config.js
+++ b/rpc-tests/config.js
@@ -49,6 +49,7 @@ const config = (network) => ({
           port: 31200,
           name: 'alice',
           flags: [
+            '--parachain-id=2007',
             '--unsafe-ws-external',
             '--unsafe-rpc-external',
             '--rpc-port=8545',
@@ -61,7 +62,7 @@ const config = (network) => ({
           wsPort: 9989,
           port: 31201,
           name: 'bob',
-          flags: ['--', '--execution=wasm'],
+          flags: ['--parachain-id=2007', '--', '--execution=wasm'],
         },
       ],
     },


### PR DESCRIPTION
**Pull Request Summary**

This fixes rpc tests. parachain-id is not default anymore with new release of astar. Needs to be added manually.

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [x] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)
