### PR TITLE
fix: slow down the fetching staking data for onfinality

### DIFF
--- a/src/components/dapp-staking/StakePanel.vue
+++ b/src/components/dapp-staking/StakePanel.vue
@@ -20,6 +20,24 @@
           </div>
         </template>
       </div>
+      <div v-else class="tw-mb-4">
+        <div class="tw-flex tw-flex-row" style="opacity: 0">
+          <div class="tw-w-20">{{ $t('dappStaking.yourStake') }}</div>
+          <!-- <div class="tw-font-semibold">0</div> -->
+        </div>
+        <div>
+          <div class="tw-flex tw-flex-row">
+            <div class="tw-w-20">{{ $t('dappStaking.totalStake') }}</div>
+            <!-- <div class="tw-font-semibold">0</div> -->
+            <q-skeleton animation="fade" class="skeleton--md" />
+          </div>
+          <div class="tw-mt-1 tw-flex tw-flex-row">
+            <div class="tw-w-20">{{ $t('dappStaking.stakersCount') }}</div>
+            <!-- <div class="tw-font-semibold">0</div> -->
+            <q-skeleton animation="fade" class="skeleton--md" />
+          </div>
+        </div>
+      </div>
 
       <div v-if="!stakeInfo?.isRegistered && stakeInfo?.stakersCount > 0">
         <div>

--- a/src/components/dapp-staking/StakePanel.vue
+++ b/src/components/dapp-staking/StakePanel.vue
@@ -23,17 +23,14 @@
       <div v-else class="tw-mb-4">
         <div class="tw-flex tw-flex-row" style="opacity: 0">
           <div class="tw-w-20">{{ $t('dappStaking.yourStake') }}</div>
-          <!-- <div class="tw-font-semibold">0</div> -->
         </div>
         <div>
           <div class="tw-flex tw-flex-row">
             <div class="tw-w-20">{{ $t('dappStaking.totalStake') }}</div>
-            <!-- <div class="tw-font-semibold">0</div> -->
             <q-skeleton animation="fade" class="skeleton--md" />
           </div>
           <div class="tw-mt-1 tw-flex tw-flex-row">
             <div class="tw-w-20">{{ $t('dappStaking.stakersCount') }}</div>
-            <!-- <div class="tw-font-semibold">0</div> -->
             <q-skeleton animation="fade" class="skeleton--md" />
           </div>
         </div>

--- a/src/modules/dapp-staking/index.ts
+++ b/src/modules/dapp-staking/index.ts
@@ -4,6 +4,7 @@ export {
   getDappStakers,
   getLatestStakePoint,
   getStakeInfo,
+  checkIsLimitedProvider,
 } from './utils';
 
 export type ContractEvm = {


### PR DESCRIPTION
**Pull Request Summary**

* fix: slow down the fetching data on Staking page (only for Onfinality)
Since Onfinality has set the limit (100requests / sec) for sending requests from the browser, I've changed the way of querying API  in sequence instead of parallel if users selected Onfinality.

* feat: added skeleton on the StakePanel
  * gif: https://gyazo.com/659cf9e4f26b5b9db3020d401395b3a1  

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

