### PR TITLE
fix: compute `canExecuteAction` variable after users input amount on StakeModal

### DIFF
--- a/src/components/dapp-staking/modals/StakeModal.vue
+++ b/src/components/dapp-staking/modals/StakeModal.vue
@@ -242,7 +242,7 @@ export default defineComponent({
     });
 
     const canExecuteAction = computed(() => {
-      if (data.value) {
+      if (data.value && data.value.amount) {
         const amount = plasmUtils.parseTo18Decimals(data.value.amount);
         const useableStakeAmount = props.accountData.getUsableFeeBalance();
 


### PR DESCRIPTION
**Pull Request Summary**

* fix: compute `canExecuteAction` variable after users input amount on StakeModal

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**


**Fixes**

=Before=
