### PR TITLE
fix: display the 'dapp register modal' properly

### DIFF
--- a/src/components/common/Modal.vue
+++ b/src/components/common/Modal.vue
@@ -1,10 +1,6 @@
 <template>
   <Teleport to="#app--main">
-    <div
-      class="tw-fixed tw-inset-0 tw-overflow-y-auto"
-      :class="!isLoading && 'highest-z-index'"
-      @click="closeModal()"
-    >
+    <div class="tw-fixed tw-inset-0 tw-overflow-y-auto" :class="!isLoading && 'highest-z-index'">
       <div class="tw-flex tw-items-center tw-justify-center tw-min-h-screen">
         <!-- Background overlay -->
         <div class="tw-fixed tw-inset-0 tw-transition-opacity" aria-hidden="true">


### PR DESCRIPTION
**Pull Request Summary**

* fix: avoid closing the 'dapp register modal' whenever users click inside of modal

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

=Before=
https://gyazo.com/e50e2c4a392ac7615197d502dd0ae253

=After=
https://gyazo.com/8fb54745b61c5b64027c0e51211b7bd4