### PR TITLE
feat: Display dApps whenever users select Shiden or Shibuya networks

### DIFF
--- a/src/components/dapp-staking/dapp/Dapp.vue
+++ b/src/components/dapp-staking/dapp/Dapp.vue
@@ -23,6 +23,7 @@ import Builders from 'src/components/dapp-staking/dapp/Builders.vue';
 import ProjectOverview from 'src/components/dapp-staking/dapp/ProjectOverview.vue';
 import ProjectDetails from 'src/components/dapp-staking/dapp/ProjectDetails.vue';
 import { useClaimAll } from 'src/hooks';
+import { useI18n } from 'vue-i18n';
 
 export default defineComponent({
   components: {
@@ -38,9 +39,11 @@ export default defineComponent({
     const route = useRoute();
     // Demo: Remove it later
     useClaimAll();
+    const { t } = useI18n();
     const store = useStore();
     const { dapps, stakingList } = useStakingList();
     const dappAddress = computed<string>(() => route.query.dapp as string);
+    const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
 
     const dispatchGetDapps = (): void => {
       const isDispatch = currentNetworkName.value && dapps.value.length === 0;
@@ -48,6 +51,12 @@ export default defineComponent({
         store.dispatch('dapps/getDapps', {
           network: currentNetworkName.value.toLowerCase(),
           currentAccount: '',
+        });
+      }
+      if (isH160.value) {
+        store.dispatch('general/showAlertMsg', {
+          msg: t('dappStaking.error.onlySupportsSubstrate'),
+          alertType: 'error',
         });
       }
     };

--- a/src/components/dapp-staking/dapp/DappAvatar.vue
+++ b/src/components/dapp-staking/dapp/DappAvatar.vue
@@ -25,7 +25,7 @@
       </div>
     </div>
     <div class="column--edit">
-      <astar-button class="btn-size--stake">
+      <astar-button class="btn-size--stake" :disabled="isDisabledEditButton">
         <span class="text--btn-stake">
           {{ $t('dappStaking.edit') }}
         </span>
@@ -55,10 +55,14 @@ export default defineComponent({
     };
 
     const isDisabledStakeButton = computed<boolean>(() => isH160.value || !currentAccount.value);
+    const isDisabledEditButton = computed<boolean>(
+      () => currentAccount.value !== props.dapp.contract.developerAddress
+    );
 
     return {
       buildStakePageLink,
       isDisabledStakeButton,
+      isDisabledEditButton,
     };
   },
 });

--- a/src/components/dapp-staking/dapp/DappAvatar.vue
+++ b/src/components/dapp-staking/dapp/DappAvatar.vue
@@ -15,7 +15,7 @@
         </div>
         <div class="row--stake">
           <router-link :to="buildStakePageLink(dapp.dapp.address)">
-            <astar-button class="btn-size--stake">
+            <astar-button class="btn-size--stake" :disabled="isDisabledStakeButton">
               <span class="text--btn-stake">
                 {{ $t('dappStaking.stake') }}
               </span>
@@ -34,8 +34,10 @@
   </div>
 </template>
 <script lang="ts">
+import { useAccount } from 'src/hooks';
 import { networkParam, Path } from 'src/router/routes';
-import { defineComponent } from 'vue';
+import { useStore } from 'src/store';
+import { defineComponent, computed } from 'vue';
 export default defineComponent({
   props: {
     dapp: {
@@ -44,12 +46,19 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const store = useStore();
+    const { currentAccount } = useAccount();
+    const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
     const buildStakePageLink = (address: string): string => {
       const base = networkParam + Path.DappStaking + Path.Stake;
       return `${base}?dapp=${address.toLowerCase()}`;
     };
+
+    const isDisabledStakeButton = computed<boolean>(() => isH160.value || !currentAccount.value);
+
     return {
       buildStakePageLink,
+      isDisabledStakeButton,
     };
   },
 });

--- a/src/components/dapp-staking/dapp/DappImages.vue
+++ b/src/components/dapp-staking/dapp/DappImages.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="wrapper--dapp-images">
+  <div v-if="images.length > 0" class="wrapper--dapp-images">
     <div class="row--images">
       <button class="button-arrow" @click="scrollLeft">
         <astar-icon-arrow-left-long class="button-arrow" :size="arrowSize" />
@@ -72,9 +72,10 @@ export default defineComponent({
 
     const arrowSize = computed<number>(() => (width.value > screenSize.sm ? 40 : 30));
     const images = computed<string[]>(() => {
-      if (props.dapp && props.dapp.dapp.imagesUrl.length > 0) {
-        return props.dapp.dapp.imagesUrl;
-      } else {
+      try {
+        const isImages = props.dapp && props.dapp.dapp.imagesUrl.length > 0;
+        return isImages ? props.dapp.dapp.imagesUrl : [];
+      } catch (error) {
         return [];
       }
     });

--- a/src/hooks/useClaimAll.ts
+++ b/src/hooks/useClaimAll.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n';
 import { useGasPrice, useCurrentEra, useCustomSignature, useNetworkInfo } from 'src/hooks';
 import { ISubmittableResult } from '@polkadot/types/types';
 import BN from 'bn.js';
@@ -21,9 +22,11 @@ export function useClaimAll() {
   const senderAddress = computed(() => store.getters['general/selectedAddress']);
   const substrateAccounts = computed(() => store.getters['general/substrateAccounts']);
   const dapps = computed(() => store.getters['dapps/getAllDapps']);
+  const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
   const isSendingTx = computed(() => store.getters['general/isLoading']);
   const { nativeTipPrice } = useGasPrice();
   const { currentNetworkName } = useNetworkInfo();
+  const { t } = useI18n();
 
   const { era } = useCurrentEra();
   const { handleResult, handleCustomExtrinsic, isCustomSig } = useCustomSignature({
@@ -44,7 +47,7 @@ export function useClaimAll() {
 
       const txs: PayloadWithWeight[] = await Promise.all(
         dapps.value.map(async (it: any) => {
-          if (it.contract.state === SmartContractState.Registered) {
+          if (it.contract.state === SmartContractState.Registered && !isH160.value) {
             const transactions = await getIndividualClaimTxs({
               dappAddress: it.dapp.address,
               api,
@@ -126,6 +129,12 @@ export function useClaimAll() {
       store.dispatch('dapps/getDapps', {
         network: currentNetworkName.value.toLowerCase(),
         currentAccount: senderAddress.value,
+      });
+    }
+    if (isH160.value) {
+      store.dispatch('general/showAlertMsg', {
+        msg: t('dappStaking.error.onlySupportsSubstrate'),
+        alertType: 'error',
       });
     }
   };

--- a/src/hooks/useClaimAll.ts
+++ b/src/hooks/useClaimAll.ts
@@ -9,6 +9,7 @@ import { TxType } from 'src/hooks/custom-signature/message';
 import { ExtrinsicPayload } from 'src/hooks/helper';
 import { getIndividualClaimTxs, PayloadWithWeight } from 'src/hooks/helper/claim';
 import { signAndSend } from 'src/hooks/helper/wallet';
+import { SmartContractState } from 'src/v2/models/DappsStaking';
 
 const MAX_BATCH_WEIGHT = new BN('50000000000');
 
@@ -43,7 +44,7 @@ export function useClaimAll() {
 
       const txs: PayloadWithWeight[] = await Promise.all(
         dapps.value.map(async (it: any) => {
-          if (it.contract.state === 'Registered') {
+          if (it.contract.state === SmartContractState.Registered) {
             const transactions = await getIndividualClaimTxs({
               dappAddress: it.dapp.address,
               api,

--- a/src/store/dapp-staking/getters.ts
+++ b/src/store/dapp-staking/getters.ts
@@ -22,9 +22,13 @@ const getters: GetterTree<State, StateInterface> & ContractsGetters = {
   getAllDapps: (state) => Object.values(state.dappsCombinedInfo),
   getRegisteredDapps: (state) => (tag) =>
     tag
-      ? state.dappsCombinedInfo.filter(
-          (x) => x.dapp?.tags.includes(tag) && x.contract.state === SmartContractState.Registered
-        )
+      ? state.dappsCombinedInfo.filter((x) => {
+          try {
+            return x.dapp?.tags.includes(tag) && x.contract.state === SmartContractState.Registered;
+          } catch (error) {
+            return state.dappsCombinedInfo;
+          }
+        })
       : state.dappsCombinedInfo,
   getMinimumStakingAmount: (state) => state.minimumStakingAmount,
   getMaxNumberOfStakersPerContract: (state) => state.maxNumberOfStakersPerContract,

--- a/src/v2/components/dapp-staking/DappCard.vue
+++ b/src/v2/components/dapp-staking/DappCard.vue
@@ -19,7 +19,7 @@
     <!-- Todo: fix the styling later-->
     <div>
       <router-link :to="buildStakePageLink(dapp.dapp.address)">
-        <button class="btn btn--sm">Stake Now</button>
+        <button class="btn btn--sm" :disabled="isH160">Stake Now</button>
       </router-link>
       <router-link :to="buildDappPageLink(dapp.dapp.address)">
         <button class="btn btn--sm">Details</button>
@@ -29,9 +29,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, toRefs } from 'vue';
+import { defineComponent, PropType, toRefs, computed } from 'vue';
 import { DappCombinedInfo } from 'src/v2/models/DappsStaking';
 import { networkParam, Path } from 'src/router/routes';
+import { useStore } from 'src/store';
 
 export default defineComponent({
   props: {
@@ -41,6 +42,8 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const store = useStore();
+    const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
     const buildStakePageLink = (address: string): string => {
       const base = networkParam + Path.DappStaking + Path.Stake;
       return `${base}?dapp=${address.toLowerCase()}`;
@@ -54,6 +57,7 @@ export default defineComponent({
       ...toRefs(props),
       buildStakePageLink,
       buildDappPageLink,
+      isH160,
     };
   },
 });

--- a/src/v2/components/dapp-staking/DappsList.vue
+++ b/src/v2/components/dapp-staking/DappsList.vue
@@ -8,10 +8,11 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, toRefs } from 'vue';
+import { computed, defineComponent, toRefs, watchEffect } from 'vue';
 import { useStore } from 'src/store';
 import { DappCombinedInfo } from 'src/v2/models/DappsStaking';
 import DappCard from 'src/v2/components/dapp-staking/DappCard.vue';
+import { useI18n } from 'vue-i18n';
 
 export default defineComponent({
   components: {
@@ -25,9 +26,20 @@ export default defineComponent({
   },
   setup(props) {
     const store = useStore();
+    const { t } = useI18n();
+    const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
     const dapps = computed<DappCombinedInfo[]>(() =>
       store.getters['dapps/getRegisteredDapps'](props.tag)
     );
+
+    watchEffect(() => {
+      if (isH160.value) {
+        store.dispatch('general/showAlertMsg', {
+          msg: t('dappStaking.error.onlySupportsSubstrate'),
+          alertType: 'error',
+        });
+      }
+    });
 
     return {
       ...toRefs(props),

--- a/src/v2/repositories/implementations/DappStakingRepository.ts
+++ b/src/v2/repositories/implementations/DappStakingRepository.ts
@@ -1,3 +1,4 @@
+import { isValidAddressPolkadotAddress } from 'src/hooks/helper/plasmUtils';
 import { BN } from '@polkadot/util';
 import { u32, Option, Struct } from '@polkadot/types';
 import { Codec, ISubmittableResult } from '@polkadot/types/types';
@@ -69,15 +70,20 @@ export class DappStakingRepository implements IDappStakingRepository {
     contractAddress: string,
     walletAddress: string
   ): Promise<string> {
-    const api = await this.api.getApi();
-    const stakerInfo = await api.query.dappsStaking.generalStakerInfo<GeneralStakerInfo>(
-      walletAddress,
-      {
-        Evm: contractAddress,
-      }
-    );
-    const balance = stakerInfo.stakes.length && stakerInfo.stakes.slice(-1)[0].staked.toString();
-    return String(balance);
+    try {
+      if (isValidAddressPolkadotAddress(walletAddress)) return '0';
+      const api = await this.api.getApi();
+      const stakerInfo = await api.query.dappsStaking.generalStakerInfo<GeneralStakerInfo>(
+        walletAddress,
+        {
+          Evm: contractAddress,
+        }
+      );
+      const balance = stakerInfo.stakes.length && stakerInfo.stakes.slice(-1)[0].staked.toString();
+      return String(balance);
+    } catch (error) {
+      return '0';
+    }
   }
 
   public async getBondAndStakeCall(


### PR DESCRIPTION
**Pull Request Summary**

* fix: Enables 'Edit' button to developer account only
* fix: Display dApps whenever users use EVM wallets to connect to the portal
* fix: Display dApps whenever users select Shiden or Shibuya networks 

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**

fix: Display dApps whenever users select Shiden or Shibuya networks
* Shiden
=Before=
<img width="1402" alt="image" src="https://user-images.githubusercontent.com/92044428/196368564-54b462ea-a504-4ccf-838e-12722ba9b19b.png">

=After=
<img width="1401" alt="image" src="https://user-images.githubusercontent.com/92044428/196368604-10ec073e-8c38-4b06-b763-d5a3041de1f1.png">

* When users connect to EVM wallets
=Before=
<img width="1410" alt="image" src="https://user-images.githubusercontent.com/92044428/196368963-2fab0273-459c-43b2-b3ef-a60a23f48fd9.png">

=After=
<img width="1401" alt="image" src="https://user-images.githubusercontent.com/92044428/196369139-3718c8e7-043f-4bce-b647-dbbb0e74eae6.png">

* Enables 'Edit' button to developer account only
![image](https://user-images.githubusercontent.com/92044428/196369584-981f75e8-df8b-4d9d-9aed-da83b97672db.png)
