### PR TITLE
Filter dapps by mainCategory

### DIFF
--- a/src/components/dapp-staking-v2/StakingTop.vue
+++ b/src/components/dapp-staking-v2/StakingTop.vue
@@ -18,7 +18,15 @@
 
     <div class="divider"></div>
 
-    <DappList category="Games" />
+    <DappList category="Tooling" />
+
+    <div class="divider"></div>
+
+    <DappList category="Utility" />
+
+    <div class="divider"></div>
+
+    <DappList category="Others" />
   </div>
 </template>
 

--- a/src/components/dapp-staking-v2/my-staking/DappList.vue
+++ b/src/components/dapp-staking-v2/my-staking/DappList.vue
@@ -23,7 +23,7 @@ export default defineComponent({
   setup(props) {
     const store = useStore();
     const dapps = computed<DappCombinedInfo[]>(() =>
-      store.getters['dapps/getRegisteredDapps'](props.category)
+      store.getters['dapps/getRegisteredDapps'](props.category.toLowerCase())
     );
 
     //TODO: need refactor as module

--- a/src/store/dapp-staking/getters.ts
+++ b/src/store/dapp-staking/getters.ts
@@ -8,6 +8,7 @@ export interface ContractsGetters {
   getAllDapps(state: State): DappCombinedInfo[];
   getRegisteredDapps(state: State): (tag: string) => DappCombinedInfo[];
   getStakerDapps(state: State): DappCombinedInfo[];
+  getRegisteredDapps(state: State): (mainCategory: string) => DappCombinedInfo[];
   getMinimumStakingAmount(state: State): string;
   getMaxNumberOfStakersPerContract(state: State): number;
   getUnbondingPeriod(state: State): number;
@@ -21,12 +22,14 @@ export interface ContractsGetters {
 
 const getters: GetterTree<State, StateInterface> & ContractsGetters = {
   getAllDapps: (state) => Object.values(state.dappsCombinedInfo),
-  getRegisteredDapps: (state) => (tag) =>
-    tag
+  getRegisteredDapps: (state) => (mainCategory) =>
+    mainCategory
       ? state.dappsCombinedInfo.filter((x) => {
           try {
             return (
-              x.dapp?.tags?.includes(tag) && x.contract.state === SmartContractState.Registered
+              (x.dapp?.mainCategory === mainCategory ||
+                (x.dapp?.mainCategory === undefined && mainCategory === 'others')) &&
+              x.contract.state === SmartContractState.Registered
             );
           } catch (error) {
             return state.dappsCombinedInfo;


### PR DESCRIPTION
**Pull Request Summary**

Implemented filtering dapps by mainCategory property. Since this is the v2 property current dapps are categorized as Others since they don't have the property set yet. After projects update their dapps with category info dapps will be categorized properly.

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/8452361/197462401-6225575d-ce4d-4f5f-a18f-353608e9eccf.png">


**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)
