### PR TITLE
fix: modified tabs styling on the `MyStaking` panel for mobile devices

### DIFF
--- a/src/components/dapp-staking-v2/my-staking/MyStaking.vue
+++ b/src/components/dapp-staking-v2/my-staking/MyStaking.vue
@@ -5,13 +5,17 @@
       <div class="wrapper--tabs responsive">
         <nav class="tabs">
           <div class="tab" :class="currentTab === 0 ? 'active' : ''" @click="currentTab = 0">
-            {{ $t('dappStaking.myRewards') }}
+            <span class="text--tab">
+              {{ $t('dappStaking.myRewards') }}
+            </span>
           </div>
           <div class="tab" :class="currentTab === 1 ? 'active' : ''" @click="currentTab = 1">
-            {{ $t('dappStaking.unbonding') }}
+            <span class="text--tab"> {{ $t('dappStaking.unbonding') }} </span>
           </div>
           <div class="tab" :class="currentTab === 2 ? 'active' : ''" @click="currentTab = 2">
-            {{ $t('dappStaking.myDapps') }}
+            <span class="text--tab">
+              {{ $t('dappStaking.myDapps') }}
+            </span>
           </div>
         </nav>
 

--- a/src/components/dapp-staking-v2/my-staking/styles/my-staking.scss
+++ b/src/components/dapp-staking-v2/my-staking/styles/my-staking.scss
@@ -11,6 +11,7 @@
   margin-left: 6px;
   margin-bottom: 24px;
 }
+
 .staking-container {
   grid-template-columns: repeat(auto-fit, minmax(288px, max-content));
   background: #fff;
@@ -20,11 +21,10 @@
 }
 
 .wrapper--tabs {
-  display: flex;
   justify-content: space-between;
-
-  @media (max-width: $md) {
-    display: block;
+  display: block;
+  @media (min-width: $md) {
+    display: flex;
   }
 }
 
@@ -37,11 +37,10 @@
   font-weight: 600;
   font-size: 14px;
   color: $gray-3;
-  margin-top: 16px;
   text-align: right;
-
-  @media (max-width: $lg) {
-    margin-top: 32px;
+  margin-top: 32px;
+  @media (min-width: $lg) {
+    margin-top: 16px;
   }
 }
 
@@ -52,9 +51,14 @@
 
 .tabs {
   border-collapse: separate;
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 12px;
+  display: flex;
+  justify-content: space-between;
+  @media (min-width: 400px) {
+    display: inline-flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
   &.tabs-center {
     margin: auto;
   }
@@ -62,15 +66,22 @@
     width: 100%;
     table-layout: fixed;
   }
+
+  .text--tab {
+    color: $gray-5-selected;
+    font-size: 14px;
+    font-weight: 400;
+    @media (min-width: 400px) {
+      font-size: 16px;
+    }
+  }
+
   .tab {
     position: relative;
     display: table-cell;
     transition: all ease 0.3s;
     padding: 14px 10px;
     transform: translate3d(0, 0, 0);
-    color: $gray-5-selected;
-    font-size: 16px;
-    font-weight: 400;
     font-style: normal;
     white-space: nowrap;
     cursor: pointer;
@@ -110,9 +121,7 @@
     box-shadow: 0px 0px 20px 5px rgba(0, 0, 0, 0.15);
   }
 
-  .tabs {
-    .tab {
-      color: $gray-1;
-    }
+  .text--tab {
+    color: $gray-1;
   }
 }


### PR DESCRIPTION
**Pull Request Summary**

* fix: modified tabs styling on the `MyStaking` panel for mobile devices

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**
* fix: modified tabs styling on the `MyStaking` panel for mobile devices
=Before=
<img src="https://user-images.githubusercontent.com/92044428/198503219-cd16a0e1-8789-481b-99e5-cdfc6cd9de6d.png" width="375px" />

=After=
![image](https://user-images.githubusercontent.com/92044428/198503296-9d4691f6-444f-4456-8524-25cd28a3ea6e.png)
