### PR TITLE
Hotfix - loading indicator not visible when modal opens up

### DIFF
--- a/src/components/dapp-staking-v2/my-staking/MyDapps.vue
+++ b/src/components/dapp-staking-v2/my-staking/MyDapps.vue
@@ -62,7 +62,7 @@
     </template>
 
     <Teleport to="#app--main">
-      <div :class="'highest-z-index'">
+      <div>
         <ModalUnbondDapp
           v-model:is-open="showModalUnbond"
           :show="showModalUnbond"

--- a/src/components/dapp-staking-v2/my-staking/UnbondingList.vue
+++ b/src/components/dapp-staking-v2/my-staking/UnbondingList.vue
@@ -46,7 +46,7 @@
     </template>
 
     <Teleport to="#app--main">
-      <div :class="'highest-z-index'">
+      <div>
         <modal-withdraw
           v-model:is-open="showModalWithdraw"
           :show="showModalWithdraw"


### PR DESCRIPTION
**Pull Request Summary**

I found that there's z-index problem between modal and loading indicator. we need resolve it later.
but for now, while transaction on the modal, loading indicator is not visible. because z-index of modal  is more higher than loading indicator one. so to visible loading indicator, opened hot fix for this.

![스크린샷 2022-11-03 오후 5 18 46](https://user-images.githubusercontent.com/1606820/199674929-9d478182-4a89-42b1-b204-63d187f734ac.png)
