### PR TITLE
fix: navigate the URL to the 'dApp staking page' after staking transaction has been completed

### DIFF
--- a/src/components/dapp-staking/dapp/Dapp.vue
+++ b/src/components/dapp-staking/dapp/Dapp.vue
@@ -1,21 +1,21 @@
 <template>
   <div v-if="dapp">
-    <DappAvatar :dapp="dapp" />
-    <DappStatistics :dapp="dapp" />
-    <DappImages :dapp="dapp" />
-    <Builders :dapp="dapp" />
+    <dapp-avatar :dapp="dapp" />
+    <dapp-statistics :dapp="dapp" />
+    <dapp-images :dapp="dapp" />
+    <builders :dapp="dapp" />
     <div class="row--project-overview">
-      <ProjectOverview :dapp="dapp" />
-      <ProjectDetails :dapp="dapp" />
+      <project-overview :dapp="dapp" />
+      <project-details :dapp="dapp" />
     </div>
   </div>
 </template>
 <script lang="ts">
-import { useNetworkInfo, useStakingList } from 'src/hooks';
+import { useNetworkInfo, useStakingList, useDappRedirect } from 'src/hooks';
 import { Path } from 'src/router';
 import { useStore } from 'src/store';
 import { computed, defineComponent, watchEffect } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { useRoute } from 'vue-router';
 import DappAvatar from 'src/components/dapp-staking/dapp/DappAvatar.vue';
 import DappStatistics from 'src/components/dapp-staking/dapp/DappStatistics.vue';
 import DappImages from 'src/components/dapp-staking/dapp/DappImages.vue';
@@ -36,7 +36,7 @@ export default defineComponent({
   setup() {
     const { currentNetworkName } = useNetworkInfo();
     const route = useRoute();
-    const router = useRouter();
+    useDappRedirect();
     const { t } = useI18n();
     const store = useStore();
     const { dapps, stakingList } = useStakingList();
@@ -72,20 +72,6 @@ export default defineComponent({
       }
       return null;
     });
-
-    const handleRedirect = (): void => {
-      if (dappAddress.value && dapps.value.length > 0) {
-        const dapp = dapps.value.find(
-          (it: any) => it.contract.address.toLowerCase() === dappAddress.value.toLowerCase()
-        );
-        !dapp &&
-          router.push({
-            path: Path.DappStaking,
-          });
-      }
-    };
-
-    watchEffect(handleRedirect);
     watchEffect(dispatchGetDapps);
 
     return {

--- a/src/components/dapp-staking/dapp/Dapp.vue
+++ b/src/components/dapp-staking/dapp/Dapp.vue
@@ -15,7 +15,7 @@ import { useNetworkInfo, useStakingList } from 'src/hooks';
 import { Path } from 'src/router';
 import { useStore } from 'src/store';
 import { computed, defineComponent, watchEffect } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import DappAvatar from 'src/components/dapp-staking/dapp/DappAvatar.vue';
 import DappStatistics from 'src/components/dapp-staking/dapp/DappStatistics.vue';
 import DappImages from 'src/components/dapp-staking/dapp/DappImages.vue';
@@ -36,6 +36,7 @@ export default defineComponent({
   setup() {
     const { currentNetworkName } = useNetworkInfo();
     const route = useRoute();
+    const router = useRouter();
     const { t } = useI18n();
     const store = useStore();
     const { dapps, stakingList } = useStakingList();
@@ -72,6 +73,19 @@ export default defineComponent({
       return null;
     });
 
+    const handleRedirect = (): void => {
+      if (dappAddress.value && dapps.value.length > 0) {
+        const dapp = dapps.value.find(
+          (it: any) => it.contract.address.toLowerCase() === dappAddress.value.toLowerCase()
+        );
+        !dapp &&
+          router.push({
+            path: Path.DappStaking,
+          });
+      }
+    };
+
+    watchEffect(handleRedirect);
     watchEffect(dispatchGetDapps);
 
     return {

--- a/src/components/dapp-staking/stake-manage/StakeManage.vue
+++ b/src/components/dapp-staking/stake-manage/StakeManage.vue
@@ -45,12 +45,18 @@ import StakeForm from 'src/components/dapp-staking/stake-manage/StakeForm.vue';
 import SelectFunds from 'src/components/dapp-staking/stake-manage/SelectFunds.vue';
 import StakeInformation from 'src/components/dapp-staking/stake-manage/StakeInformation.vue';
 import ModalSelectFunds from 'src/components/dapp-staking/stake-manage/ModalSelectFunds.vue';
-import { useBreakpoints, useNetworkInfo, useStake, useStakingList } from 'src/hooks';
+import {
+  useBreakpoints,
+  useNetworkInfo,
+  useStake,
+  useStakingList,
+  useDappRedirect,
+} from 'src/hooks';
 import { wait } from 'src/hooks/helper/common';
 import { Path } from 'src/router';
 import { useStore } from 'src/store';
 import { computed, defineComponent, ref, watchEffect } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { useRoute } from 'vue-router';
 
 export type StakeRightUi = 'information' | 'select-funds-from';
 
@@ -70,7 +76,7 @@ export default defineComponent({
     const { screenSize, width } = useBreakpoints();
     const { currentNetworkName } = useNetworkInfo();
     const route = useRoute();
-    const router = useRouter();
+    useDappRedirect();
     const { setAddressTransferFrom, formattedTransferFrom, currentAccount, handleStake } =
       useStake();
 
@@ -133,19 +139,6 @@ export default defineComponent({
       isModalSelectFunds.value && handleModalSelectFunds({ isOpen: false });
     };
 
-    const handleRedirect = (): void => {
-      if (dappAddress.value && dapps.value.length > 0) {
-        const dapp = dapps.value.find(
-          (it: any) => it.contract.address.toLowerCase() === dappAddress.value.toLowerCase()
-        );
-        !dapp &&
-          router.push({
-            path: Path.DappStaking,
-          });
-      }
-    };
-
-    watchEffect(handleRedirect);
     watchEffect(dispatchGetDapps);
 
     return {

--- a/src/components/dapp-staking/stake-manage/StakeManage.vue
+++ b/src/components/dapp-staking/stake-manage/StakeManage.vue
@@ -50,7 +50,7 @@ import { wait } from 'src/hooks/helper/common';
 import { Path } from 'src/router';
 import { useStore } from 'src/store';
 import { computed, defineComponent, ref, watchEffect } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 export type StakeRightUi = 'information' | 'select-funds-from';
 
@@ -70,6 +70,7 @@ export default defineComponent({
     const { screenSize, width } = useBreakpoints();
     const { currentNetworkName } = useNetworkInfo();
     const route = useRoute();
+    const router = useRouter();
     const { setAddressTransferFrom, formattedTransferFrom, currentAccount, handleStake } =
       useStake();
 
@@ -119,8 +120,6 @@ export default defineComponent({
       return null;
     });
 
-    watchEffect(dispatchGetDapps);
-
     const cancelHighlight = async (e: any): Promise<void> => {
       const openClass = 'container--select-funds';
       if (isHighlightRightUi.value && e.target.className !== openClass) {
@@ -133,6 +132,21 @@ export default defineComponent({
       await setRightUi('information');
       isModalSelectFunds.value && handleModalSelectFunds({ isOpen: false });
     };
+
+    const handleRedirect = (): void => {
+      if (dappAddress.value && dapps.value.length > 0) {
+        const dapp = dapps.value.find(
+          (it: any) => it.contract.address.toLowerCase() === dappAddress.value.toLowerCase()
+        );
+        !dapp &&
+          router.push({
+            path: Path.DappStaking,
+          });
+      }
+    };
+
+    watchEffect(handleRedirect);
+    watchEffect(dispatchGetDapps);
 
     return {
       isHighlightRightUi,

--- a/src/hooks/dapps-staking/useDappRedirect.ts
+++ b/src/hooks/dapps-staking/useDappRedirect.ts
@@ -1,0 +1,26 @@
+import { Path } from 'src/router';
+import { useStore } from 'src/store';
+import { computed, watchEffect } from 'vue';
+import { useRouter } from 'vue-router';
+
+// Memo: Redirect to /dapp-staking/discover when users change the networks on the staking or dApp page
+export function useDappRedirect() {
+  const store = useStore();
+  const router = useRouter();
+  const dappAddress = computed<string>(() => router.currentRoute.value.query.dapp as string);
+  const dapps = computed(() => store.getters['dapps/getAllDapps']);
+
+  const handleRedirect = (): void => {
+    if (dappAddress.value && dapps.value.length > 0) {
+      const dapp = dapps.value.find(
+        (it: any) => it.contract.address.toLowerCase() === dappAddress.value.toLowerCase()
+      );
+      !dapp &&
+        router.push({
+          path: Path.DappStaking,
+        });
+    }
+  };
+
+  watchEffect(handleRedirect);
+}

--- a/src/hooks/dapps-staking/useStake.ts
+++ b/src/hooks/dapps-staking/useStake.ts
@@ -7,12 +7,14 @@ import { container } from 'src/v2/common';
 import { IDappStakingService } from 'src/v2/services';
 import { Symbols } from 'src/v2/symbols';
 import { computed, ref, watch } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRouter, useRoute } from 'vue-router';
 
 export function useStake() {
   const router = useRouter();
+  const route = useRoute();
   const { currentAccount } = useAccount();
   const { stakingList } = useStakingList();
+  const isStakePage = computed<boolean>(() => route.fullPath.includes('stake'));
   useChainMetadata();
   const addressTransferFrom = ref<string>(currentAccount.value);
 
@@ -59,7 +61,7 @@ export function useStake() {
     } else {
       await dappStakingService.stake(targetContractId, currentAccount.value, stakeAmount);
     }
-    router.push(Path.DappStaking);
+    isStakePage.value && router.push(Path.DappStaking);
   };
 
   watch(

--- a/src/hooks/dapps-staking/useUnbonding.ts
+++ b/src/hooks/dapps-staking/useUnbonding.ts
@@ -81,7 +81,7 @@ export function useUnbonding() {
   const unsub = subscribeToEraChange();
 
   const getChunks = async (era: u32) => {
-    if (!canUnbondWithdraw.value) {
+    if (!canUnbondWithdraw.value || !selectedAccountAddress.value) {
       return;
     }
 
@@ -111,7 +111,7 @@ export function useUnbonding() {
   watch(
     () => unlockingChunksCount.value,
     async (chunks) => {
-      console.log('chunks count changed');
+      // console.log('chunks count changed');
       const era = await $api?.query.dappsStaking.currentEra<u32>();
       if (era) {
         await getChunks(era);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -29,6 +29,7 @@ export * from './dapps-staking/useNominationTransfer';
 export * from './dapps-staking/useStakerInfo';
 export * from './dapps-staking/useStakingList';
 export * from './dapps-staking/useSignPayload';
+export * from './dapps-staking/useDappRedirect';
 export * from './wallet/useWalletIcon';
 export * from './wallet/useEvmWallet';
 export * from './xcm/useXcmBridgeV3';

--- a/src/hooks/useClaimAll.ts
+++ b/src/hooks/useClaimAll.ts
@@ -66,7 +66,6 @@ export function useClaimAll() {
       canClaim.value = batchTxs.length > 0;
 
       amountOfEras.value = batchTxs.length;
-      console.log('Amount of Eras to claim: batchTxs.length', batchTxs.length);
     } catch (error: any) {
       console.error(error.message);
     } finally {

--- a/src/v2/repositories/implementations/DappStakingRepository.ts
+++ b/src/v2/repositories/implementations/DappStakingRepository.ts
@@ -227,7 +227,6 @@ export class DappStakingRepository implements IDappStakingRepository {
     if (!DappStakingRepository.isEraSubscribed) {
       const api = await this.api.getApi();
       await api.query.dappsStaking.currentEra((era: u32) => {
-        console.log('New era: ', era.toString());
         this.eventAggregator.publish(new NewEraMessage(era.toNumber()));
       });
       DappStakingRepository.isEraSubscribed = true;

--- a/src/v2/services/implementations/PolkadotWalletService.ts
+++ b/src/v2/services/implementations/PolkadotWalletService.ts
@@ -76,7 +76,8 @@ export class PolkadotWalletService extends WalletService implements IWalletServi
               this.eventAggregator.publish(new BusyMessage(false));
               resolve(extrinsic.hash.toHex());
             } else {
-              this.eventAggregator.publish(new BusyMessage(true));
+              const isLoad = !result.isCompleted || !result.isInBlock;
+              isLoad && this.eventAggregator.publish(new BusyMessage(true));
             }
           }
         );

--- a/src/v2/services/implementations/PolkadotWalletService.ts
+++ b/src/v2/services/implementations/PolkadotWalletService.ts
@@ -76,8 +76,7 @@ export class PolkadotWalletService extends WalletService implements IWalletServi
               this.eventAggregator.publish(new BusyMessage(false));
               resolve(extrinsic.hash.toHex());
             } else {
-              const isLoad = !result.isCompleted || !result.isInBlock;
-              isLoad && this.eventAggregator.publish(new BusyMessage(true));
+              !result.isCompleted && this.eventAggregator.publish(new BusyMessage(true));
             }
           }
         );


### PR DESCRIPTION
**Pull Request Summary**

* fix: navigate the URL to the 'dApp staking page' after staking transaction has been completed 
  *  avoid navigating to the 'dApp staking page' if users have go to other pages before staking transaction has been completed 

* fix: modified an error at DappStakingService.ts
* fix: removed unused console.log
* fix: added redirect logic on the staking and dApp page

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**

* fix: navigate the URL to the 'dApp staking page' after staking transaction has been completed 
  *  avoid navigating to the 'dApp staking page' if users have go to other pages before staking transaction has been completed 

=Before=
https://www.loom.com/share/6e274c60f24746b6a856f51fc94d2e62

=After=
https://www.loom.com/share/b8e21aad93854574b6995eb093a0f8b5

* fix: modified an error in DappStakingService.ts

![Screenshot 2022-11-09 at 2 37 42 PM](https://user-images.githubusercontent.com/92044428/200778053-9206ebc4-880f-4eb0-8182-cd9c953efa90.png)

* fix: added redirect logic on the staking and dApp page

=Before=
https://www.loom.com/share/48484b24a7a842979471a4413500c17e

=After=
https://www.loom.com/share/9b392f62b31a437db32ad6e3d21eccb6
