### PR TITLE
Fix：Fix the problem of paging overflow when clicking the paging button quickly

### DIFF
--- a/src/components/dapp-staking-v2/my-staking/OnChainData.vue
+++ b/src/components/dapp-staking-v2/my-staking/OnChainData.vue
@@ -231,7 +231,7 @@ export default defineComponent({
       isDisplay.value = false;
       goToNext.value = isNext;
       setTimeout(() => {
-        isNext ? page.value++ : page.value--;
+        isNext ? ((page.value < pageTtl.value) ? page.value++ : pageTtl.value) : ((page.value > 1) ? page.value-- : 1);
         isDisplay.value = true;
       }, 700);
     };


### PR DESCRIPTION
Fix the problem of paging overflow when clicking the paging button quickly


**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**


**Fixes**
- Fix the problem of paging overflow when clicking the paging button quickly

before
![telegram-cloud-photo-size-5-6329831391512081178-y](https://user-images.githubusercontent.com/17961901/203067507-a2af652d-80d7-42ef-b98c-bdb954cebfd9.jpg)

