### PR TITLE
Fix：Fix the problem of paging overflow when clicking the paging button quickly

### DIFF
--- a/src/components/dapp-staking-v2/my-staking/OnChainData.vue
+++ b/src/components/dapp-staking-v2/my-staking/OnChainData.vue
@@ -231,7 +231,11 @@ export default defineComponent({
       isDisplay.value = false;
       goToNext.value = isNext;
       setTimeout(() => {
-        isNext ? ((page.value < pageTtl.value) ? page.value++ : pageTtl.value) : ((page.value > 1) ? page.value-- : 1);
+        if (isNext) {
+          page.value < pageTtl.value ? page.value++ : pageTtl.value;
+        } else {
+          page.value > 1 ? page.value-- : 1;
+        }
         isDisplay.value = true;
       }, 700);
     };


### PR DESCRIPTION
**Pull Request Summary**
Fix：Fix the problem of paging overflow when clicking the paging button quickly

After the repair, it will no longer appear: the page on the previous page becomes negative after multiple clicks
- before : https://gyazo.com/5fad336025d5eaa14e378f08babf17fc
- after : https://gyazo.com/c8d2d2ae70203025b3e1ed774ff948e6

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**
- Fix：Fix the problem of paging overflow when clicking the paging button quickly，The page number overflow problem occurs when the user of the original code clicks the previous page quickly


- [ guoyizhang ] (ex: add user list)