### PR TITLE
Developer unique name check

### DIFF
--- a/src/components/dapp-staking/register/Builders.vue
+++ b/src/components/dapp-staking/register/Builders.vue
@@ -35,6 +35,7 @@
           :add-developer="handleAddDevelper"
           :update-developer="handleUpdateDeveloper"
           :developer="currentDeveloper"
+          :check-if-developer-exists="checkIfDeveloperExists"
         />
       </div>
     </teleport>
@@ -107,7 +108,7 @@ export default defineComponent({
 
     const handleUpdateDeveloper = (developer: Developer): void => {
       const developerIndex = data.developers.findIndex(
-        (x) => x.name === currentDeveloper.value.name
+        (x) => x.name.toLowerCase() === currentDeveloper.value.name.toLowerCase()
       );
       if (developerIndex > -1) {
         data.developers[developerIndex] = developer;
@@ -116,6 +117,16 @@ export default defineComponent({
       }
 
       isModalAddDeveloper.value = false;
+    };
+
+    const checkIfDeveloperExists = (developerName: string): boolean => {
+      return (
+        data.developers.findIndex(
+          (x: Developer) =>
+            x.name.toLowerCase() === developerName.toLowerCase() &&
+            x.name.toLowerCase() !== currentDeveloper.value.name.toLowerCase()
+        ) >= 0
+      );
     };
 
     watch(
@@ -136,6 +147,7 @@ export default defineComponent({
       handleAddDevelper,
       handleUpdateDeveloper,
       handleModalAddDeveloper,
+      checkIfDeveloperExists,
     };
   },
 });

--- a/src/components/dapp-staking/register/ModalAddDeveloper.vue
+++ b/src/components/dapp-staking/register/ModalAddDeveloper.vue
@@ -78,11 +78,14 @@
           input-class="input"
           :input-style="{ fontWeight: 'bold' }"
           lazy-rules="ondemand"
-          :rules="[(v: string) => (v && v.length > 0) || `${$t('dappStaking.modals.builder.error.name')}`]"
+          :rules="[
+              (v: string) => (v && v.length > 0) || `${$t('dappStaking.modals.builder.error.name')}`,
+              (v: string) => !checkIfDeveloperExists(v) || `${$t('dappStaking.modals.builder.error.nameExists')}`
+          ]"
           class="component"
         />
 
-        <div class="validation-warning">
+        <div class="validation-warning margin">
           <li>{{ $t('dappStaking.modals.builder.error.buildersRequired') }}</li>
           <li>{{ $t('dappStaking.modals.builder.error.builderUrlRequired') }}</li>
           <li>{{ $t('dappStaking.modals.builder.imageRecomendation') }}</li>
@@ -130,6 +133,10 @@ export default defineComponent({
       required: true,
     },
     updateDeveloper: {
+      type: Function,
+      required: true,
+    },
+    checkIfDeveloperExists: {
       type: Function,
       required: true,
     },
@@ -245,5 +252,9 @@ export default defineComponent({
   font-weight: 600;
   height: 44px;
   align-self: center;
+}
+
+.margin {
+  margin-top: 20px;
 }
 </style>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -336,6 +336,7 @@ export default {
         imageRecomendation: 'A square image of minimum 500px is recommended.',
         error: {
           name: 'Builder name is required.',
+          nameExists: 'Given name is already used by another developer',
           invalidUrl: 'Invalid url.',
           accountRequired: 'At least one account is required.',
           builderImageRequired: 'Builder image is required',


### PR DESCRIPTION
**Pull Request Summary**

Fix for a bug in registration page when user was able to give the same name to multiple developers. Since name is the key for search when updating developers, this caused issue with overriding data of other developer and some other problems.

I believe this caused yesterday's issue with XY finance registration.

<img width="494" alt="image" src="https://user-images.githubusercontent.com/8452361/203503761-d8ea4fa0-45a7-47d3-858a-3a836ec2472b.png">


**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
