### PR TITLE
fix: modified stylings for Crust integration

### DIFF
--- a/src/components/assets/styles/asset-list-xcm.scss
+++ b/src/components/assets/styles/asset-list-xcm.scss
@@ -26,10 +26,10 @@
   row-gap: 16px;
   @media (min-width: $md) {
     display: grid;
-    grid-template-columns: 290px 190px;
+    grid-template-columns: 190px 190px;
   }
   @media (min-width: $lg) {
-    grid-template-columns: 280px 220px;
+    grid-template-columns: 140px 220px;
   }
   @media (min-width: $xl) {
     grid-template-columns: 300px 290px;

--- a/src/components/assets/styles/asset-list.scss
+++ b/src/components/assets/styles/asset-list.scss
@@ -59,10 +59,10 @@
   row-gap: 16px;
   @media (min-width: $md) {
     display: grid;
-    grid-template-columns: 290px 190px;
+    grid-template-columns: 290px 140px;
   }
   @media (min-width: $lg) {
-    grid-template-columns: 280px 220px;
+    grid-template-columns: 280px 150px;
   }
   @media (min-width: $xl) {
     grid-template-columns: 300px 290px;
@@ -75,16 +75,16 @@
 .row__right--evm {
   @media (min-width: $md) {
     display: grid;
-    grid-template-columns: 260px 190px;
+    grid-template-columns: 260px 120px;
   }
   @media (min-width: $lg) {
-    grid-template-columns: 200px 190px;
+    grid-template-columns: 200px 160px;
   }
   @media (min-width: $xl) {
-    grid-template-columns: 280px auto;
+    grid-template-columns: 220px auto;
   }
   @media (min-width: $xxl) {
-    grid-template-columns: 360px auto;
+    grid-template-columns: 340px auto;
   }
 }
 

--- a/src/modules/xcm/utils/index.ts
+++ b/src/modules/xcm/utils/index.ts
@@ -170,14 +170,6 @@ export const castChainName = (chain: string): string => {
     return chain + ' ' + '(Native)';
   }
   if (chain.includes('-')) {
-    // const name = chain.replace('-', ' ');
-    // const test = chain.split('-');
-    // const test2 = test.map((it) => capitalize(it));
-    // const test3 = test2.join(' ');
-    // console.log('test', test);
-    // console.log('test2', test2);
-    // console.log('test3', test3);
-    // return name;
     return chain
       .split('-')
       .map((it) => capitalize(it))

--- a/src/modules/xcm/utils/index.ts
+++ b/src/modules/xcm/utils/index.ts
@@ -9,7 +9,7 @@ import {
   updateAccountHistories,
 } from 'src/config/localStorage';
 import { pathEvm } from 'src/hooks';
-import { getTimestamp } from 'src/hooks/helper/common';
+import { getTimestamp, capitalize } from 'src/hooks/helper/common';
 import { astarNetworks } from 'src/hooks/xcm/useTransferRouter';
 import { SystemAccount, TxHistory } from 'src/modules/account';
 import { HistoryTxType } from 'src/modules/account/index';
@@ -168,6 +168,20 @@ export const castChainName = (chain: string): string => {
   }
   if (chain && astarNetworks.includes(chain.toLowerCase())) {
     return chain + ' ' + '(Native)';
+  }
+  if (chain.includes('-')) {
+    // const name = chain.replace('-', ' ');
+    // const test = chain.split('-');
+    // const test2 = test.map((it) => capitalize(it));
+    // const test3 = test2.join(' ');
+    // console.log('test', test);
+    // console.log('test2', test2);
+    // console.log('test3', test3);
+    // return name;
+    return chain
+      .split('-')
+      .map((it) => capitalize(it))
+      .join(' ');
   }
   return chain;
 };


### PR DESCRIPTION
**Pull Request Summary**

* fix: modified row styling for 'Crust Shadow Native Token'
* fix: cast the network name from 'Crust-shadow' to 'Crust Shadow' (for UI)

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**

* fix: modified row styling for 'Crust Shadow Native Token'
=Before=
![image](https://user-images.githubusercontent.com/92044428/204253517-189ff9f1-c978-49b3-8f70-5ef969d076de.png)

![image](https://user-images.githubusercontent.com/92044428/204253642-99191dd2-b28c-4d38-a852-edd7e213e37c.png)

=After=

![image](https://user-images.githubusercontent.com/92044428/204253897-2a7aea64-ff70-43c0-a915-961bfa90d0f0.png)

* fix: cast the network name from 'Crust-shadow' to 'Crust Shadow' (for UI)

=Before=
![image](https://user-images.githubusercontent.com/92044428/204254348-f5bc3a25-bd19-4b09-8488-f30125fe69c7.png)


=After=

![image](https://user-images.githubusercontent.com/92044428/204254267-2db2f55c-6016-408d-867e-30aa9c7f0dea.png)
