### PR TITLE
Temporary disable auto restaking on claim all

### DIFF
--- a/src/v2/models/DappsStaking.ts
+++ b/src/v2/models/DappsStaking.ts
@@ -46,8 +46,11 @@ export interface ChunkInfo {
   erasBeforeUnlock: number;
 }
 
+export type RewardDestination = 'StakeBalance' | 'FreeBalance';
+
 export interface AccountLedger {
   locked: BN;
+  rewardDestination: RewardDestination;
   unbondingInfo: {
     unlockingChunks: ChunkInfo[];
   };

--- a/src/v2/repositories/implementations/DappStakingRepository.ts
+++ b/src/v2/repositories/implementations/DappStakingRepository.ts
@@ -9,7 +9,12 @@ import { IDappStakingRepository } from 'src/v2/repositories';
 import { IApi } from 'src/v2/integration';
 import { Symbols } from 'src/v2/symbols';
 import { ApiPromise } from '@polkadot/api';
-import { SmartContract, SmartContractState, StakerInfo } from 'src/v2/models/DappsStaking';
+import {
+  RewardDestination,
+  SmartContract,
+  SmartContractState,
+  StakerInfo,
+} from 'src/v2/models/DappsStaking';
 import { EventAggregator, NewEraMessage } from 'src/v2/messaging';
 import { GeneralStakerInfo } from 'src/hooks/helper/claim';
 import { ethers } from 'ethers';
@@ -57,6 +62,7 @@ interface SmartContractAddress extends Struct {
 
 interface PalletDappsStakingAccountLedger extends Codec {
   locked: Balance;
+  rewardDestination: Codec;
   unbondingInfo: UnbondingInfo;
 }
 
@@ -261,6 +267,7 @@ export class DappStakingRepository implements IDappStakingRepository {
 
     return {
       locked: ledger.locked.toBn(),
+      rewardDestination: <RewardDestination>ledger.rewardDestination.toString(),
       unbondingInfo: {
         unlockingChunks: ledger.unbondingInfo.unlockingChunks.map((x) => {
           return {


### PR DESCRIPTION
**Pull Request Summary**

In a situation when staked array size reach `maxEraStakeValues` (currently set to 5) users are unable to clam their reward if auto restaking is on.
![image](https://user-images.githubusercontent.com/8452361/204735669-d43b6f1b-ae6f-4475-b45b-13cedc5ccd8e.png)

Changed logic to turn off auto restaking before claim and turn it on after rewards are claimed.


**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**


**Fixes**
- Claim error
