### PR TITLE
fix: temporary disabled staking-historic-UI

### DIFF
--- a/src/components/dapp-staking-v2/stake-manage/StakeManage.vue
+++ b/src/components/dapp-staking-v2/stake-manage/StakeManage.vue
@@ -44,8 +44,8 @@ import BackToPage from 'src/components/common/BackToPage.vue';
 import ModalSelectFunds from './ModalSelectFunds.vue';
 import SelectFunds from './SelectFunds.vue';
 import StakeForm from './StakeForm.vue';
-// import StakeInformation from './StakeInformation.vue';
-import StakeInformation from 'src/components/dapp-staking/stake-manage/StakeInformation.vue';
+import StakeInformation from './StakeInformation.vue';
+// import StakeInformation from 'src/components/dapp-staking/stake-manage/StakeInformation.vue';
 import { WalletModalOption } from 'src/config/wallets';
 import {
   useBreakpoints,


### PR DESCRIPTION
**Pull Request Summary**

* fix: temporary hide the Recent History UI (dApp staking V2.1)

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**
=Before=
![image](https://user-images.githubusercontent.com/92044428/205217501-fa3f5c73-9293-4f75-85b0-36605b1d787c.png)


=After=
![image](https://user-images.githubusercontent.com/92044428/205217551-e4131cce-6804-46b3-8aa2-bc67767c00a2.png)
