### PR TITLE
Re-stake status display fix

### DIFF
--- a/src/hooks/dapps-staking/useCompoundRewards.ts
+++ b/src/hooks/dapps-staking/useCompoundRewards.ts
@@ -172,7 +172,7 @@ export function useCompoundRewards() {
       if (!currentAddress.value) return;
       await Promise.all([checkIsClaimable(), getCompoundingType()]);
     },
-    { immediate: false }
+    { immediate: true }
   );
 
   return {


### PR DESCRIPTION
**Pull Request Summary**

Something re-stake after claiming was displayed wrong. Although re-stake was enabled on chain, portal was showing off status.
<img width="545" alt="image" src="https://user-images.githubusercontent.com/8452361/205494199-b711ef24-bfe6-426a-a678-2acf91ee495c.png">



**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
