### PR TITLE
Fetch APR/APY from Token API

### DIFF
--- a/src/components/dapp-staking-v2/my-staking/TopMetric.vue
+++ b/src/components/dapp-staking-v2/my-staking/TopMetric.vue
@@ -102,7 +102,7 @@ import {
   AccountLedger,
   RewardDestination,
   useAccount,
-  useApr,
+  useAprFromApi,
   useAvgBlockTime,
   useNetworkInfo,
 } from 'src/hooks';
@@ -117,7 +117,7 @@ export default defineComponent({
   components: { PieChart },
   setup() {
     const store = useStore();
-    const { stakerApr, stakerApy } = useApr();
+    const { stakerApr, stakerApy } = useAprFromApi();
     const { currentAccount } = useAccount();
     const dappsCount = computed<DappCombinedInfo[]>(
       () => store.getters['dapps/getRegisteredDapps']().length

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,6 +8,7 @@ export * from './useChainMetadata';
 export * from './useGetMinStaking';
 export * from './useEvmDeposit';
 export * from './useApr';
+export * from './useAprFromApi';
 export * from './useCurrentEra';
 export * from './useFaucet';
 export * from './useChainInfo';

--- a/src/hooks/useAprFromApi.ts
+++ b/src/hooks/useAprFromApi.ts
@@ -1,0 +1,31 @@
+import { container } from 'src/v2/common';
+import { IDappStakingRepository } from 'src/v2/repositories';
+import { Symbols } from 'src/v2/symbols';
+import { ref, watchEffect } from 'vue';
+import { useNetworkInfo } from './useNetworkInfo';
+
+export const useAprFromApi = () => {
+  const stakerApr = ref<number>(0);
+  const stakerApy = ref<number>(0);
+  const { currentNetworkName } = useNetworkInfo();
+  const repository = container.get<IDappStakingRepository>(Symbols.DappStakingRepository);
+
+  watchEffect(async () => {
+    try {
+      if (currentNetworkName.value) {
+        const result = await repository.getApr(currentNetworkName.value);
+        stakerApr.value = result.apr;
+        stakerApy.value = result.apy;
+      }
+    } catch (err) {
+      stakerApr.value = 0;
+      stakerApy.value = 0;
+      console.error(err);
+    }
+  });
+
+  return {
+    stakerApr,
+    stakerApy,
+  };
+};

--- a/src/v2/repositories/IDappStakingRepository.ts
+++ b/src/v2/repositories/IDappStakingRepository.ts
@@ -76,4 +76,10 @@ export interface IDappStakingRepository {
    * @param accountAddress User account.
    */
   getLedger(accountAddress: string): Promise<AccountLedger>;
+
+  /**
+   * Gets dapp staking APR and APY values for a given network.
+   * @param network Network to fetch values for.
+   */
+  getApr(network: string): Promise<{ apr: number; apy: number }>;
 }

--- a/src/v2/repositories/implementations/DappStakingRepository.ts
+++ b/src/v2/repositories/implementations/DappStakingRepository.ts
@@ -280,6 +280,18 @@ export class DappStakingRepository implements IDappStakingRepository {
     };
   }
 
+  public async getApr(network: string): Promise<{ apr: number; apy: number }> {
+    Guard.ThrowIfUndefined('network', network);
+
+    const baseUrl = `${TOKEN_API_URL}/v1/${network.toLowerCase()}/dapps-staking`;
+    const [apr, apy] = await Promise.all([
+      (await axios.get<number>(`${baseUrl}/apr`)).data,
+      (await axios.get<number>(`${baseUrl}/apy`)).data,
+    ]);
+
+    return { apr, apy };
+  }
+
   private async getCurrentEra(api: ApiPromise): Promise<u32> {
     return await api.query.dappsStaking.currentEra<u32>();
   }

--- a/src/v2/test/mocks/repositories/DappStakingRepositoryMock.ts
+++ b/src/v2/test/mocks/repositories/DappStakingRepositoryMock.ts
@@ -84,4 +84,8 @@ export class DappStakingRepositoryMock implements IDappStakingRepository {
   public async getLedger(accountAddress: string): Promise<AccountLedger> {
     return {} as AccountLedger;
   }
+
+  public async getApr(network: string): Promise<{ apr: number; apy: number }> {
+    return { apr: 0, apy: 0 };
+  }
 }


### PR DESCRIPTION
**Pull Request Summary**

Because of an [issue](https://github.com/paritytech/smoldot/issues/1925) we are facing while calculating APR/APY over light client I changed code to switch those values from Token API. 

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
