### PR TITLE
fix: enables `light client` endpoint option for localhost or staging url

### DIFF
--- a/src/components/header/modals/ModalNetwork.vue
+++ b/src/components/header/modals/ModalNetwork.vue
@@ -263,8 +263,9 @@ export default defineComponent({
     const checkIsDisplayEndpoint = (chain: ChainProvider, endpoint: string): boolean => {
       const origin = window.location.origin;
       const stagingDomain = '.web.app';
-      const isDevMode = origin.includes(stagingDomain || 'localhost:');
-      if (isDevMode || chain.key === endpointKey.SHIBUYA) {
+      const devPaths = [stagingDomain, 'localhost:'];
+      const isForDeveloper = devPaths.some((it) => origin.includes(it));
+      if (isForDeveloper || chain.key === endpointKey.SHIBUYA) {
         return true;
       } else {
         return !checkIsLightClient(endpoint);

--- a/src/components/header/modals/ModalNetwork.vue
+++ b/src/components/header/modals/ModalNetwork.vue
@@ -52,6 +52,7 @@
                           :key="i"
                         >
                           <div
+                            v-if="checkIsDisplayEndpoint(provider, endpointObj.endpoint)"
                             class="column--network-option"
                             @click="setSelEndpoint({ endpointObj, networkIdx: index })"
                           >
@@ -93,7 +94,8 @@
 </template>
 <script lang="ts">
 import { $endpoint } from 'src/boot/api';
-import { endpointKey, providerEndpoints } from 'src/config/chainEndpoints';
+import { checkIsLightClient } from 'src/config/api/polkadot/connectApi';
+import { ChainProvider, endpointKey, providerEndpoints } from 'src/config/chainEndpoints';
 import { LOCAL_STORAGE } from 'src/config/localStorage';
 import { getRandomFromArray, wait } from 'src/hooks/helper/common';
 import { buildNetworkUrl } from 'src/router/utils';
@@ -255,6 +257,20 @@ export default defineComponent({
       }
     };
 
+    // Memo: Displays Light client option if:
+    // A: users select Shibuya
+    // B: the portal is opened on 'localhost' or 'staging URL'
+    const checkIsDisplayEndpoint = (chain: ChainProvider, endpoint: string): boolean => {
+      const origin = window.location.origin;
+      const stagingDomain = '.web.app';
+      const isDevMode = origin.includes(stagingDomain || 'localhost:');
+      if (isDevMode || chain.key === endpointKey.SHIBUYA) {
+        return true;
+      } else {
+        return !checkIsLightClient(endpoint);
+      }
+    };
+
     watch(
       [$endpoint, selNetwork],
       () => {
@@ -289,6 +305,7 @@ export default defineComponent({
       setSelEndpoint,
       checkIsCheckedEndpoint,
       windowHeight,
+      checkIsDisplayEndpoint,
     };
   },
 });

--- a/src/config/api/polkadot/connectApi.ts
+++ b/src/config/api/polkadot/connectApi.ts
@@ -14,6 +14,8 @@ const RES_TIMEOUT = 'timeout';
 
 type Provider = WsProvider | ScProvider;
 
+export const checkIsLightClient = (endpoint: string): boolean => endpoint.startsWith('light://');
+
 const getParachainSpec = (networkIdx: endpointKey): string => {
   switch (networkIdx) {
     case endpointKey.ASTAR:
@@ -40,7 +42,6 @@ const getWellKnownChain = (networkIdx: endpointKey): WellKnownChain | string => 
   }
 };
 
-const isLightClient = (endpoint: string): boolean => endpoint.startsWith('light://');
 const isSubstrateConnectInstalled = (): boolean =>
   !!document.getElementById('substrateConnectExtensionAvailable');
 
@@ -59,7 +60,7 @@ const fallbackConnection = async ({
   }
 
   const filteredEndpoints = providerEndpoints[networkIdx].endpoints.filter((it) => {
-    return it.endpoint !== endpoint && !isLightClient(it.endpoint);
+    return it.endpoint !== endpoint && !checkIsLightClient(it.endpoint);
   });
   if (1 >= filteredEndpoints.length) {
     return window.location.reload();
@@ -124,7 +125,7 @@ export async function connectApi(
   store.commit('general/setLoading', true);
 
   try {
-    if (isLightClient(endpoint) && isSubstrateConnectInstalled()) {
+    if (checkIsLightClient(endpoint) && isSubstrateConnectInstalled()) {
       const parachainSpec = getParachainSpec(networkIdx);
       const relayProvider = new ScProvider(getWellKnownChain(networkIdx));
       provider = new ScProvider(parachainSpec, relayProvider);
@@ -147,7 +148,7 @@ export async function connectApi(
     });
 
     const fallbackTimeout = new Promise<string>(async (resolve) => {
-      const timeout = isLightClient(endpoint) ? 50 * 1000 : 8 * 1000;
+      const timeout = checkIsLightClient(endpoint) ? 50 * 1000 : 8 * 1000;
       await wait(timeout);
       resolve(RES_TIMEOUT);
     });


### PR DESCRIPTION
**Pull Request Summary**

* fix: enables `light client` endpoint option (for Astar and Shiden) for localhost or staging url only ([ref](https://github.com/AstarNetwork/astar-apps/blob/238668c36ad7550efea67074ecad45ecb1529910/src/components/header/modals/ModalNetwork.vue#L260))
  * Shibuya: enabled in any URLs  

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**
* fix: enables `light client` endpoint option for localhost or staging url only ([ref](https://github.com/AstarNetwork/astar-apps/blob/238668c36ad7550efea67074ecad45ecb1529910/src/components/header/modals/ModalNetwork.vue#L260))

```
    // Memo: Displays Light client option if:
    // A: users select Shibuya
    // B: the portal is opened on 'localhost' or 'staging URL'
```

=Staging URL / localhost=
![image](https://user-images.githubusercontent.com/92044428/210321703-6e4f2066-36d1-4e71-a1ca-f4db95f65090.png)



=Production (assume as)=
URL: https://astar-portal-6nk95q6do-impelcrypto.vercel.app/#/astar/assets

![image](https://user-images.githubusercontent.com/92044428/210319077-bd4f917d-350b-45c5-9524-76320d276b64.png)

![image](https://user-images.githubusercontent.com/92044428/210319095-d9a24e0f-7867-4bf7-be95-7bcef841bfe7.png)
