### PR TITLE
Migrate business logic in dapp staking v2 to new architecture

### DIFF
--- a/src/v2/repositories/IDappStakingRepository.ts
+++ b/src/v2/repositories/IDappStakingRepository.ts
@@ -6,7 +6,7 @@ import { EditDappItem } from 'src/store/dapp-staking/state';
 import { AccountLedger } from '../models/DappsStaking';
 import { u32 } from '@polkadot/types';
 import { GeneralStakerInfo } from 'src/hooks/helper/claim';
-
+import { PayloadWithWeight } from './implementations/DappStakingRepository';
 /**
  * Definition of repository to access dapps staking pallet.
  */
@@ -90,4 +90,8 @@ export interface IDappStakingRepository {
     stakerAddress: string,
     contractAddress: string
   ): Promise<Map<string, GeneralStakerInfo>>;
+
+  getTxsToExecuteForClaim(
+    batchTxs: PayloadWithWeight[]
+  ): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>>;
 }

--- a/src/v2/repositories/IExtrinsicCallRepository.ts
+++ b/src/v2/repositories/IExtrinsicCallRepository.ts
@@ -1,0 +1,12 @@
+import { ISubmittableResult } from '@polkadot/types/types';
+import type { SubmittableExtrinsic } from '@polkadot/api/types';
+import { EcdsaAccount } from 'src/store/general/state';
+
+export interface IExtrinsicCallRepository {
+  getCallFunc(
+    method: SubmittableExtrinsic<'promise', ISubmittableResult>,
+    currentEcdsaAccount: EcdsaAccount,
+    currentNetworkIdx: number,
+    requestSignature: (message: string, account: string) => Promise<string>
+  ): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>>;
+}

--- a/src/v2/repositories/implementations/ExtrinsicCallRepository.ts
+++ b/src/v2/repositories/implementations/ExtrinsicCallRepository.ts
@@ -1,0 +1,45 @@
+import { injectable, inject } from 'inversify';
+import { Symbols } from 'src/v2/symbols';
+import { AccountInfo } from '@polkadot/types/interfaces';
+import { IApi } from 'src/v2/integration';
+import { IExtrinsicCallRepository } from '../IExtrinsicCallRepository';
+import { ISubmittableResult } from '@polkadot/types/types';
+import { EventAggregator } from 'src/v2/messaging';
+import type { SubmittableExtrinsic } from '@polkadot/api/types';
+import { u8aToHex } from '@polkadot/util';
+import { getPayload } from 'src/hooks/extrinsic/payload';
+import { providerEndpoints } from 'src/config/chainEndpoints';
+import { EcdsaAccount } from 'src/store/general/state';
+
+@injectable()
+export class ExtrinsicCallRepository implements IExtrinsicCallRepository {
+  constructor(
+    @inject(Symbols.DefaultApi) private api: IApi,
+    @inject(Symbols.EventAggregator) private eventAggregator: EventAggregator
+  ) {}
+
+  public async getCallFunc(
+    method: SubmittableExtrinsic<'promise', ISubmittableResult>,
+    currentEcdsaAccount: EcdsaAccount,
+    currentNetworkIdx: number,
+    requestSignature: (message: string, account: string) => Promise<string>
+  ): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>> {
+    const api = await this.api.getApi();
+    const account = <AccountInfo>await api?.query.system.account(currentEcdsaAccount.ss58);
+    const callPayload = u8aToHex(
+      getPayload(method, account.nonce, providerEndpoints[currentNetworkIdx].prefix || 0)
+    );
+
+    if (!callPayload) {
+      throw Error('toast.unableCalculateMsgPayload');
+      // store.dispatch('general/showAlertMsg', {
+      //   msg: t('toast.unableCalculateMsgPayload'),
+      //   alertType: 'error',
+      // });
+    }
+    // Sign transaction with eth private key
+    const signature = await requestSignature(callPayload, currentEcdsaAccount.ethereum);
+    const call = api?.tx.ethCall.call(method, currentEcdsaAccount.ss58, signature, account.nonce);
+    return call;
+  }
+}

--- a/src/v2/repositories/implementations/index.ts
+++ b/src/v2/repositories/implementations/index.ts
@@ -13,3 +13,4 @@ export * from './xcm/PhalaXcmRepository';
 export * from './TokenApiRepository';
 export * from './EvmAssetsRepository';
 export * from './xcm/CrustShadowXcmRepository';
+export * from './ExtrinsicCallRepository';

--- a/src/v2/repositories/index.ts
+++ b/src/v2/repositories/index.ts
@@ -6,3 +6,4 @@ export * from './IEthCallRepository';
 export * from './IXcmRepository';
 export * from './IXvmRepository';
 export * from './IEvmAssetsRepository';
+export * from './IExtrinsicCallRepository';

--- a/src/v2/services/IDappStakingService.ts
+++ b/src/v2/services/IDappStakingService.ts
@@ -3,10 +3,10 @@ import { EditDappItem } from 'src/store/dapp-staking/state';
 import { TvlModel } from 'src/v2/models';
 import { DappCombinedInfo, StakerInfo } from '../models/DappsStaking';
 import { AccountLedger } from '../models/DappsStaking';
-import { SubmittableExtrinsic } from '@polkadot/api/types';
-import { ISubmittableResult } from '@polkadot/types/types';
 import { SubstrateAccount } from 'src/store/general/state';
 import { PayloadWithWeight } from 'src/hooks/helper/claim';
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { ISubmittableResult } from '@polkadot/types/types';
 
 /**
  * Definition of service used to manage dapps staking.
@@ -85,24 +85,19 @@ export interface IDappStakingService {
    */
   canClaimRewardWithoutErrors(accountAddress: string): Promise<boolean>;
 
+  getTxsToExecuteForClaim(
+    batchTxs: PayloadWithWeight[]
+  ): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>>;
+
   claimAll({
     batchTxs,
     senderAddress,
     substrateAccounts,
-    isCustomSignature = false,
-    txResHandler,
-    handleCustomExtrinsic,
     tip,
   }: {
     batchTxs: PayloadWithWeight[];
     senderAddress: string;
     substrateAccounts: SubstrateAccount[];
-    isCustomSignature: boolean;
-    txResHandler: (result: ISubmittableResult) => Promise<boolean>;
-    // from: useCustomSignature.ts
-    handleCustomExtrinsic?: (
-      method: SubmittableExtrinsic<'promise', ISubmittableResult>
-    ) => Promise<void>;
     tip?: string;
   }): Promise<void>;
 }

--- a/src/v2/services/IDappStakingService.ts
+++ b/src/v2/services/IDappStakingService.ts
@@ -3,6 +3,10 @@ import { EditDappItem } from 'src/store/dapp-staking/state';
 import { TvlModel } from 'src/v2/models';
 import { DappCombinedInfo, StakerInfo } from '../models/DappsStaking';
 import { AccountLedger } from '../models/DappsStaking';
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { ISubmittableResult } from '@polkadot/types/types';
+import { SubstrateAccount } from 'src/store/general/state';
+import { PayloadWithWeight } from 'src/hooks/helper/claim';
 
 /**
  * Definition of service used to manage dapps staking.
@@ -80,4 +84,25 @@ export interface IDappStakingService {
    * @param accountAddress User account address
    */
   canClaimRewardWithoutErrors(accountAddress: string): Promise<boolean>;
+
+  claimAll({
+    batchTxs,
+    senderAddress,
+    substrateAccounts,
+    isCustomSignature = false,
+    txResHandler,
+    handleCustomExtrinsic,
+    tip,
+  }: {
+    batchTxs: PayloadWithWeight[];
+    senderAddress: string;
+    substrateAccounts: SubstrateAccount[];
+    isCustomSignature: boolean;
+    txResHandler: (result: ISubmittableResult) => Promise<boolean>;
+    // from: useCustomSignature.ts
+    handleCustomExtrinsic?: (
+      method: SubmittableExtrinsic<'promise', ISubmittableResult>
+    ) => Promise<void>;
+    tip?: string;
+  }): Promise<void>;
 }

--- a/src/v2/services/IExtrinsicCallService.ts
+++ b/src/v2/services/IExtrinsicCallService.ts
@@ -1,0 +1,17 @@
+import { ISubmittableResult } from '@polkadot/types/types';
+import type { SubmittableExtrinsic } from '@polkadot/api/types';
+import { EcdsaAccount } from 'src/store/general/state';
+
+export interface IExtrinsicCallService {
+  callCustomExtrinsic(
+    method: SubmittableExtrinsic<'promise'>,
+    currentEcdsaAccount: EcdsaAccount,
+    currentNetworkIdx: number,
+    requestSignature: (message: string, account: string) => Promise<string>
+  ): Promise<void>;
+
+  send(
+    extrinsic: SubmittableExtrinsic<'promise', ISubmittableResult>,
+    successMessage?: string
+  ): Promise<string | null>;
+}

--- a/src/v2/services/IWalletService.ts
+++ b/src/v2/services/IWalletService.ts
@@ -1,4 +1,7 @@
 import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { ISubmittableResult } from '@polkadot/types/types';
+import { SubstrateAccount } from 'src/store/general/state';
+import { HistoryTxType } from 'src/modules/account';
 
 export enum WalletType {
   Metamask = 'Metamask',
@@ -19,4 +22,27 @@ export interface IWalletService {
     successMessage?: string,
     transactionTip?: number
   ): Promise<string | null>;
+
+  signAndSendWithCustomSignature({
+    transaction,
+    senderAddress,
+    substrateAccounts,
+    isCustomSignature,
+    txResHandler,
+    handleCustomExtrinsic,
+    tip,
+    txType,
+  }: {
+    transaction: SubmittableExtrinsic<'promise', ISubmittableResult>;
+    senderAddress: string;
+    substrateAccounts: SubstrateAccount[];
+    isCustomSignature: boolean;
+    txResHandler: (result: ISubmittableResult) => Promise<boolean>;
+    // from: useCustomSignature.ts
+    handleCustomExtrinsic?: (
+      method: SubmittableExtrinsic<'promise', ISubmittableResult>
+    ) => Promise<void>;
+    tip?: string;
+    txType?: HistoryTxType;
+  }): Promise<boolean>;
 }

--- a/src/v2/services/IWalletService.ts
+++ b/src/v2/services/IWalletService.ts
@@ -1,7 +1,4 @@
 import { SubmittableExtrinsic } from '@polkadot/api/types';
-import { ISubmittableResult } from '@polkadot/types/types';
-import { SubstrateAccount } from 'src/store/general/state';
-import { HistoryTxType } from 'src/modules/account';
 
 export enum WalletType {
   Metamask = 'Metamask',
@@ -22,27 +19,4 @@ export interface IWalletService {
     successMessage?: string,
     transactionTip?: number
   ): Promise<string | null>;
-
-  signAndSendWithCustomSignature({
-    transaction,
-    senderAddress,
-    substrateAccounts,
-    isCustomSignature,
-    txResHandler,
-    handleCustomExtrinsic,
-    tip,
-    txType,
-  }: {
-    transaction: SubmittableExtrinsic<'promise', ISubmittableResult>;
-    senderAddress: string;
-    substrateAccounts: SubstrateAccount[];
-    isCustomSignature: boolean;
-    txResHandler: (result: ISubmittableResult) => Promise<boolean>;
-    // from: useCustomSignature.ts
-    handleCustomExtrinsic?: (
-      method: SubmittableExtrinsic<'promise', ISubmittableResult>
-    ) => Promise<void>;
-    tip?: string;
-    txType?: HistoryTxType;
-  }): Promise<boolean>;
 }

--- a/src/v2/services/implementations/ExtrinsicCallService.ts
+++ b/src/v2/services/implementations/ExtrinsicCallService.ts
@@ -1,0 +1,80 @@
+import { inject, injectable } from 'inversify';
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { Symbols } from 'src/v2/symbols';
+import { ISubmittableResult } from '@polkadot/types/types';
+import { IExtrinsicCallService } from '../IExtrinsicCallService';
+import { IExtrinsicCallRepository } from 'src/v2/repositories/IExtrinsicCallRepository';
+import { BusyMessage, ExtrinsicStatusMessage, IEventAggregator } from 'src/v2/messaging';
+import { WalletService } from './WalletService';
+import { Guard } from 'src/v2/common';
+import { EcdsaAccount } from 'src/store/general/state';
+
+@injectable()
+export class ExtrinsicCallService extends WalletService implements IExtrinsicCallService {
+  constructor(
+    @inject(Symbols.ExtrinsicCallRepository)
+    private extrinsicCallRepository: IExtrinsicCallRepository,
+    @inject(Symbols.EventAggregator) readonly eventAggregator: IEventAggregator
+  ) {
+    super(eventAggregator);
+  }
+
+  public async callCustomExtrinsic(
+    method: SubmittableExtrinsic<'promise'>,
+    currentEcdsaAccount: EcdsaAccount,
+    currentNetworkIdx: number,
+    requestSignature: (message: string, account: string) => Promise<string>
+  ): Promise<void> {
+    try {
+      const call = await this.extrinsicCallRepository.getCallFunc(
+        method,
+        currentEcdsaAccount,
+        currentNetworkIdx,
+        requestSignature
+      );
+      this.send(call);
+    } catch (e) {
+      const error = e as unknown as Error;
+      this.eventAggregator.publish(new ExtrinsicStatusMessage(false, error.message));
+      this.eventAggregator.publish(new BusyMessage(false));
+    }
+  }
+
+  public async send(
+    extrinsic: SubmittableExtrinsic<'promise', ISubmittableResult>,
+    successMessage?: string
+  ): Promise<string | null> {
+    Guard.ThrowIfUndefined('extrinsic', extrinsic);
+
+    let result: string | null = null;
+    try {
+      return new Promise<string>(async (resolve) => {
+        await extrinsic.send((result: ISubmittableResult) => {
+          if (result.isFinalized) {
+            if (!this.isExtrinsicFailed(result.events)) {
+              this.eventAggregator.publish(
+                new ExtrinsicStatusMessage(
+                  true,
+                  successMessage ?? 'Transaction successfully executed',
+                  `${extrinsic.method.section}.${extrinsic.method.method}`,
+                  result.txHash.toHex()
+                )
+              );
+            }
+
+            this.eventAggregator.publish(new BusyMessage(false));
+            resolve(extrinsic.hash.toHex());
+          } else {
+            !result.isCompleted && this.eventAggregator.publish(new BusyMessage(true));
+          }
+        });
+      });
+    } catch (e) {
+      const error = e as unknown as Error;
+      this.eventAggregator.publish(new ExtrinsicStatusMessage(false, error.message));
+      this.eventAggregator.publish(new BusyMessage(false));
+    }
+
+    return result;
+  }
+}

--- a/src/v2/services/implementations/PolkadotWalletService.ts
+++ b/src/v2/services/implementations/PolkadotWalletService.ts
@@ -11,7 +11,9 @@ import { BusyMessage, ExtrinsicStatusMessage, IEventAggregator } from 'src/v2/me
 import { WalletService } from './WalletService';
 import { Guard, wait } from 'src/v2/common';
 import { Symbols } from 'src/v2/symbols';
-
+import { SubstrateAccount } from 'src/store/general/state';
+import { addTxHistories, HistoryTxType } from 'src/modules/account';
+import { getInjector } from 'src/hooks/helper/wallet';
 @injectable()
 export class PolkadotWalletService extends WalletService implements IWalletService {
   private readonly extensions: InjectedExtension[] = [];
@@ -88,6 +90,96 @@ export class PolkadotWalletService extends WalletService implements IWalletServi
     }
 
     return result;
+  }
+
+  // from src/hooks/helper/wallet.ts
+  // @TODO: Need to refactor
+  public async signAndSendWithCustomSignature({
+    transaction,
+    senderAddress,
+    substrateAccounts,
+    isCustomSignature = false,
+    txResHandler,
+    handleCustomExtrinsic,
+    tip,
+    txType,
+  }: {
+    transaction: SubmittableExtrinsic<'promise', ISubmittableResult>;
+    senderAddress: string;
+    substrateAccounts: SubstrateAccount[];
+    isCustomSignature: boolean;
+    txResHandler: (result: ISubmittableResult) => Promise<boolean>;
+    // from: useCustomSignature.ts
+    handleCustomExtrinsic?: (
+      method: SubmittableExtrinsic<'promise', ISubmittableResult>
+    ) => Promise<void>;
+    tip?: string;
+    txType?: HistoryTxType;
+  }): Promise<boolean> {
+    Guard.ThrowIfUndefined('transaction', transaction);
+    Guard.ThrowIfUndefined('senderAddress', senderAddress);
+    Guard.ThrowIfUndefined('substrateAccounts', substrateAccounts);
+
+    return new Promise<boolean>(async (resolve) => {
+      const sendSubstrateTransaction = async (): Promise<void> => {
+        const injector = await getInjector(substrateAccounts);
+        if (!injector) {
+          throw Error('Invalid injector');
+        }
+        await transaction.signAndSend(
+          senderAddress,
+          {
+            signer: injector.signer,
+            nonce: -1,
+            tip: tip ? ethers.utils.parseEther(String(tip)).toString() : '1',
+          },
+          (result) => {
+            if (result.isFinalized) {
+              if (!this.isExtrinsicFailed(result.events)) {
+                (async () => {
+                  const res = await txResHandler(result);
+                  this.eventAggregator.publish(
+                    new ExtrinsicStatusMessage(
+                      true,
+                      'Transaction successfully executed',
+                      `${transaction.method.section}.${transaction.method.method}`,
+                      result.txHash.toHex()
+                    )
+                  );
+
+                  if (txType) {
+                    addTxHistories({
+                      hash: result.txHash.toString(),
+                      type: txType,
+                      address: senderAddress,
+                    });
+                  }
+                  this.eventAggregator.publish(new BusyMessage(false));
+                  resolve(res);
+                })();
+              } else {
+                !result.isCompleted && this.eventAggregator.publish(new BusyMessage(true));
+              }
+            }
+          }
+        );
+      };
+
+      try {
+        if (isCustomSignature && handleCustomExtrinsic) {
+          await handleCustomExtrinsic(transaction);
+          this.eventAggregator.publish(new BusyMessage(false));
+          resolve(true);
+        } else {
+          await sendSubstrateTransaction();
+        }
+      } catch (error: any) {
+        console.error(error.message);
+        this.eventAggregator.publish(new ExtrinsicStatusMessage(false, error.message));
+        this.eventAggregator.publish(new BusyMessage(false));
+        resolve(false);
+      }
+    });
   }
 
   private async getAccounts(): Promise<Account[]> {

--- a/src/v2/services/implementations/index.ts
+++ b/src/v2/services/implementations/index.ts
@@ -7,3 +7,4 @@ export * from './XcmService';
 export * from './XcmEvmService';
 export * from './BalanceFormatterService';
 export * from './EvmAssetsService';
+export * from './ExtrinsicCallService';

--- a/src/v2/services/index.ts
+++ b/src/v2/services/index.ts
@@ -6,3 +6,4 @@ export * from './IXvmService';
 export * from './IXcmEvmService';
 export * from './IBalanceFormatterService';
 export * from './IEvmAssetsService';
+export * from './IExtrinsicCallService';

--- a/src/v2/symbols.ts
+++ b/src/v2/symbols.ts
@@ -22,4 +22,6 @@ export const Symbols = {
   CurrentWallet: Symbol.for('CurrentWallet'),
   EvmAssetsRepository: Symbol.for('EvmAssetsRepository'),
   EvmAssetsService: Symbol.for('EvmAssetsService'),
+  ExtrinsicCallService: Symbol.for('ExtrinsicCallService'),
+  ExtrinsicCallRepository: Symbol.for('ExtrinsicCallRepository'),
 };

--- a/src/v2/test/mocks/repositories/DappStakingRepositoryMock.ts
+++ b/src/v2/test/mocks/repositories/DappStakingRepositoryMock.ts
@@ -8,7 +8,7 @@ import { EditDappItem } from 'src/store/dapp-staking/state';
 import { AccountLedger } from 'src/v2/models/DappsStaking';
 import { u32 } from '@polkadot/types';
 import { GeneralStakerInfo } from 'src/hooks/helper/claim';
-
+import { PayloadWithWeight } from 'src/v2/repositories/implementations';
 @injectable()
 export class DappStakingRepositoryMock implements IDappStakingRepository {
   public readonly bondAndStakeCallMock = jest.fn();
@@ -104,5 +104,11 @@ export class DappStakingRepositoryMock implements IDappStakingRepository {
     contractAddress: string
   ): Promise<Map<string, GeneralStakerInfo>> {
     return new Map();
+  }
+
+  public async getTxsToExecuteForClaim(
+    batchTxs: PayloadWithWeight[]
+  ): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>> {
+    return {} as SubmittableExtrinsic<'promise', ISubmittableResult>;
   }
 }

--- a/src/v2/test/mocks/services/WalletServiceMock.ts
+++ b/src/v2/test/mocks/services/WalletServiceMock.ts
@@ -2,6 +2,8 @@ import { ISubmittableResult } from '@polkadot/types/types';
 import { SubmittableExtrinsic } from '@polkadot/api-base/types';
 import { injectable } from 'inversify';
 import { IWalletService } from 'src/v2/services';
+import { SubstrateAccount } from 'src/store/general/state';
+import { HistoryTxType } from 'src/modules/account';
 
 @injectable()
 export class WalletServiceMock implements IWalletService {
@@ -17,5 +19,30 @@ export class WalletServiceMock implements IWalletService {
     successMessage?: string
   ): Promise<string | null> {
     return this.walletSignAndSendMock.call(this, extrinsic, senderAddress, successMessage);
+  }
+
+  public async signAndSendWithCustomSignature({
+    transaction,
+    senderAddress,
+    substrateAccounts,
+    isCustomSignature = false,
+    txResHandler,
+    handleCustomExtrinsic,
+    tip,
+    txType,
+  }: {
+    transaction: SubmittableExtrinsic<'promise', ISubmittableResult>;
+    senderAddress: string;
+    substrateAccounts: SubstrateAccount[];
+    isCustomSignature: boolean;
+    txResHandler: (result: ISubmittableResult) => Promise<boolean>;
+    // from: useCustomSignature.ts
+    handleCustomExtrinsic?: (
+      method: SubmittableExtrinsic<'promise', ISubmittableResult>
+    ) => Promise<void>;
+    tip?: string;
+    txType?: HistoryTxType;
+  }): Promise<boolean> {
+    return this.walletSignAndSendMock.call(this, transaction, senderAddress, '');
   }
 }

--- a/src/v2/test/mocks/services/WalletServiceMock.ts
+++ b/src/v2/test/mocks/services/WalletServiceMock.ts
@@ -20,29 +20,4 @@ export class WalletServiceMock implements IWalletService {
   ): Promise<string | null> {
     return this.walletSignAndSendMock.call(this, extrinsic, senderAddress, successMessage);
   }
-
-  public async signAndSendWithCustomSignature({
-    transaction,
-    senderAddress,
-    substrateAccounts,
-    isCustomSignature = false,
-    txResHandler,
-    handleCustomExtrinsic,
-    tip,
-    txType,
-  }: {
-    transaction: SubmittableExtrinsic<'promise', ISubmittableResult>;
-    senderAddress: string;
-    substrateAccounts: SubstrateAccount[];
-    isCustomSignature: boolean;
-    txResHandler: (result: ISubmittableResult) => Promise<boolean>;
-    // from: useCustomSignature.ts
-    handleCustomExtrinsic?: (
-      method: SubmittableExtrinsic<'promise', ISubmittableResult>
-    ) => Promise<void>;
-    tip?: string;
-    txType?: HistoryTxType;
-  }): Promise<boolean> {
-    return this.walletSignAndSendMock.call(this, transaction, senderAddress, '');
-  }
 }


### PR DESCRIPTION
**Pull Request Summary**

> Refactor focusing on these hooks
- useClaimAll
- useStakerInfo
- useUnbonding

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

- refactor: use the new architecture for sending dApp staking transactions
