### PR TITLE
fix: modified fetching 'My staking information' logic when users change their account

### DIFF
--- a/src/hooks/dapps-staking/useStakerInfo.ts
+++ b/src/hooks/dapps-staking/useStakerInfo.ts
@@ -62,7 +62,7 @@ export function useStakerInfo() {
   };
 
   watchEffect(async () => {
-    if (isLoading.value || !dapps.value) {
+    if (isLoading.value || !dapps.value || !currentAccount.value) {
       return;
     }
     try {


### PR DESCRIPTION
**Pull Request Summary**

* fix: modified fetching 'My staking information' logic when users change their account

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Fixes**
* fix: modified fetching 'My staking information' logic when users change their account
  * to avoid throwing this error 

![image](https://user-images.githubusercontent.com/92044428/212256740-69adbe68-d1c2-415b-9f62-719c333a2d7c.png)

