### PR TITLE
Claim issue fix

### DIFF
--- a/src/hooks/useClaimAll.ts
+++ b/src/hooks/useClaimAll.ts
@@ -95,12 +95,13 @@ export function useClaimAll() {
     let totalWeight: BN = new BN(0);
     for (let i = 0; i < batchTxsRef.length; i++) {
       const tx = batchTxsRef[i];
-      if (totalWeight.add(tx.weight).gt(MAX_BATCH_WEIGHT)) {
+      const weight = tx.isWeightV2 ? tx.asWeightV2().refTime.toBn() : tx.asWeightV1();
+      if (totalWeight.add(weight).gt(MAX_BATCH_WEIGHT)) {
         break;
       }
 
       txsToExecute.push(tx.payload as ExtrinsicPayload);
-      totalWeight = totalWeight.add(tx.weight);
+      totalWeight = totalWeight.add(weight);
     }
 
     // The fix causes problems and confusion for stakers because rewards are not restaked,


### PR DESCRIPTION
**Pull Request Summary**

Because of weights V2 are introduced to Shibuya and Shiden claim feature stopped working.

![image](https://user-images.githubusercontent.com/8452361/212679564-9dd496b2-d0ef-4052-a68e-d0881e11bff9.png)


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

- Fix for Claim All error
