### PR TITLE
Multiple popups on dapp staking fix

### DIFF
--- a/src/components/common/Notification/NotificationStack.vue
+++ b/src/components/common/Notification/NotificationStack.vue
@@ -71,6 +71,7 @@ export default defineComponent({
   overflow-y: auto;
   overflow-x: hidden;
   gap: 10px;
+  padding-top: 16px;
   @media (min-width: $md) {
     top: 96px;
     left: auto;

--- a/src/components/dapp-staking/StakingTop.vue
+++ b/src/components/dapp-staking/StakingTop.vue
@@ -63,14 +63,18 @@ export default defineComponent({
       store.commit('general/setLoading', isLoad);
     };
 
-    watch([isH160], () => {
-      if (isH160.value) {
-        store.dispatch('general/showAlertMsg', {
-          msg: t('dappStaking.error.onlySupportsSubstrate'),
-          alertType: 'error',
-        });
-      }
-    });
+    watch(
+      [isH160],
+      () => {
+        if (isH160.value) {
+          store.dispatch('general/showAlertMsg', {
+            msg: t('dappStaking.error.onlySupportsSubstrate'),
+            alertType: 'error',
+          });
+        }
+      },
+      { immediate: true }
+    );
 
     watch(
       [dapps],

--- a/src/components/dapp-staking/dapp/Dapp.vue
+++ b/src/components/dapp-staking/dapp/Dapp.vue
@@ -84,15 +84,6 @@ export default defineComponent({
       return null;
     });
 
-    watch([isH160], () => {
-      if (isH160.value) {
-        store.dispatch('general/showAlertMsg', {
-          msg: t('dappStaking.error.onlySupportsSubstrate'),
-          alertType: 'error',
-        });
-      }
-    });
-
     return {
       Path,
       dapp,

--- a/src/components/dapp-staking/dapp/Dapp.vue
+++ b/src/components/dapp-staking/dapp/Dapp.vue
@@ -13,7 +13,7 @@
     <!-- <dapp-stats-charts :dapp="dapp" /> -->
     <div class="bottom--links">
       <router-link :to="buildStakePageLink(dapp.dapp.address)">
-        <astar-irregular-button :height="28" class="btn--stake-switch">
+        <astar-irregular-button :disabled="isH160" :height="28" class="btn--stake-switch">
           {{ $t('dappStaking.dappPage.stakeOrSwitchTo') }} {{ dapp.dapp.name }}
         </astar-irregular-button>
       </router-link>
@@ -90,6 +90,7 @@ export default defineComponent({
       stakingList,
       goLink,
       buildStakePageLink,
+      isH160,
     };
   },
 });

--- a/src/components/dapp-staking/dapp/DappAvatar.vue
+++ b/src/components/dapp-staking/dapp/DappAvatar.vue
@@ -14,13 +14,22 @@
           </div>
         </div>
         <div class="row--stake">
-          <router-link :to="buildStakePageLink(dapp.dapp.address)">
+          <!--
+            For some unknown reason disabling router/button doesn't work here (button is still clickable),
+            so I made this small trick with two buttons.
+          -->
+          <router-link v-if="!isH160" :to="buildStakePageLink(dapp.dapp.address)">
             <astar-button class="btn-size--stake">
               <span class="text--btn-stake">
                 {{ $t('dappStaking.stake') }}
               </span>
             </astar-button>
           </router-link>
+          <astar-button v-if="isH160" :disabled="true" class="btn-size--stake">
+            <span class="text--btn-stake">
+              {{ $t('dappStaking.stake') }}
+            </span>
+          </astar-button>
         </div>
       </div>
     </div>
@@ -38,6 +47,8 @@ import { useAccount } from 'src/hooks';
 import { networkParam, Path } from 'src/router/routes';
 import { defineComponent, computed } from 'vue';
 import { useRouter } from 'vue-router';
+import { useStore } from 'src/store';
+
 export default defineComponent({
   props: {
     dapp: {
@@ -48,6 +59,9 @@ export default defineComponent({
   setup(props) {
     const router = useRouter();
     const { currentAccount } = useAccount();
+    const store = useStore();
+    const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
+
     const buildStakePageLink = (address: string): string => {
       const base = networkParam + Path.DappStaking + Path.Stake;
       return `${base}?dapp=${address.toLowerCase()}`;
@@ -66,6 +80,7 @@ export default defineComponent({
       buildStakePageLink,
       isDisabledEditButton,
       goEditLink,
+      isH160,
     };
   },
 });

--- a/src/components/dapp-staking/my-staking/MyRewards.vue
+++ b/src/components/dapp-staking/my-staking/MyRewards.vue
@@ -57,7 +57,12 @@
           <div class="value">
             {{ isCompounding ? $t('dappStaking.on') : $t('dappStaking.off') }}
           </div>
-          <astar-button :width="80" :height="24" @click="changeDestinationForRestaking">
+          <astar-button
+            :disabled="isH160"
+            :width="80"
+            :height="24"
+            @click="changeDestinationForRestaking"
+          >
             {{ isCompounding ? $t('dappStaking.turnOff') : $t('dappStaking.turnOn') }}
           </astar-button>
         </div>
@@ -91,6 +96,7 @@ import { useClaimedReward } from 'src/hooks/dapps-staking/useClaimedReward';
 import { RewardDestination } from 'src/hooks/dapps-staking/useCompoundRewards';
 import { endpointKey } from 'src/config/chainEndpoints';
 import { defineComponent, computed } from 'vue';
+import { useStore } from 'src/store';
 
 export default defineComponent({
   components: {
@@ -112,6 +118,8 @@ export default defineComponent({
     const { currentAccount } = useAccount();
     const { currentNetworkIdx } = useNetworkInfo();
     const isShiden = computed(() => currentNetworkIdx.value === endpointKey.SHIDEN);
+    const store = useStore();
+    const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
     const goToSubscan = () => {
       let rootName = 'astar';
       if (isShiden.value) {
@@ -135,6 +143,7 @@ export default defineComponent({
       nativeTokenSymbol,
       isLoadingTotalStaked,
       goToSubscan,
+      isH160,
     };
   },
 });

--- a/src/components/dapp-staking/my-staking/components/CardList.vue
+++ b/src/components/dapp-staking/my-staking/components/CardList.vue
@@ -41,6 +41,7 @@
         </div>
         <astar-button
           v-if="index === hoverIndex || width < widthCardLineUp"
+          :disabled="isH160"
           class="button--stake"
           :width="274"
           :height="24"
@@ -55,11 +56,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref } from 'vue';
+import { defineComponent, PropType, ref, computed } from 'vue';
 import { useBreakpoints, useNetworkInfo } from 'src/hooks';
 import { DappCombinedInfo } from 'src/v2/models/DappsStaking';
 import { networkParam, Path } from 'src/router/routes';
 import { useRouter } from 'vue-router';
+import { useStore } from 'src/store';
 import TokenBalance from 'src/components/common/TokenBalance.vue';
 
 export default defineComponent({
@@ -77,10 +79,12 @@ export default defineComponent({
   setup() {
     const widthCardLineUp = 900;
     const router = useRouter();
+    const store = useStore();
     const { width, screenSize } = useBreakpoints();
     const hoverIndex = ref<number>(-1);
     const isToStakePage = ref<boolean>(false);
     const { nativeTokenSymbol } = useNetworkInfo();
+    const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
 
     const goStakePageLink = (address: string | undefined): void => {
       isToStakePage.value = true;
@@ -104,6 +108,7 @@ export default defineComponent({
       goDappPageLink,
       nativeTokenSymbol,
       widthCardLineUp,
+      isH160,
     };
   },
 });

--- a/src/components/dapp-staking/stake-manage/StakeManage.vue
+++ b/src/components/dapp-staking/stake-manage/StakeManage.vue
@@ -151,10 +151,6 @@ export default defineComponent({
       [isH160],
       () => {
         if (isH160.value) {
-          store.dispatch('general/showAlertMsg', {
-            msg: t('dappStaking.error.onlySupportsSubstrate'),
-            alertType: 'error',
-          });
           window.dispatchEvent(new CustomEvent(WalletModalOption.SelectWallet));
         }
       },

--- a/src/hooks/dapps-staking/useStakerInfo.ts
+++ b/src/hooks/dapps-staking/useStakerInfo.ts
@@ -75,15 +75,6 @@ export function useStakerInfo() {
     }
   });
 
-  watchEffect(() => {
-    if (isH160.value) {
-      store.dispatch('general/showAlertMsg', {
-        msg: t('dappStaking.error.onlySupportsSubstrate'),
-        alertType: 'error',
-      });
-    }
-  });
-
   watch([currentAccount, myStakeInfos], setTotalStaked);
 
   return {


### PR DESCRIPTION
**Pull Request Summary**

When connected to the portal with Metamask and open dapp staking pake three warnings pops showing that dapp staking supports Substrate wallets. After clicking on X (to close popup) another one shows. 

Before
<img width="368" alt="image" src="https://user-images.githubusercontent.com/8452361/214313795-32870925-eabc-4ae1-bf7a-b619079b381e.png">

After
<img width="373" alt="image" src="https://user-images.githubusercontent.com/8452361/214314142-8c8cdcfa-9e57-45ac-a8e5-6cd3300204f4.png">


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

- fix for displaying multiple warning on dapp staking page when connected with Metamask