### PR TITLE
feat: add support for shibuya subscan link in tx toast

### DIFF
--- a/src/components/common/Notification/NotificationBar.vue
+++ b/src/components/common/Notification/NotificationBar.vue
@@ -85,7 +85,7 @@ export default defineComponent({
     const { currentNetworkIdx } = useNetworkInfo();
     const isShiden = computed<boolean>(() => currentNetworkIdx.value === endpointKey.SHIDEN);
     const isShibuya = computed<boolean>(() => currentNetworkIdx.value === endpointKey.SHIBUYA);
-    
+
     const goToSubscan = () => {
       if (!props.txHash) return;
 

--- a/src/components/common/Notification/NotificationBar.vue
+++ b/src/components/common/Notification/NotificationBar.vue
@@ -84,13 +84,16 @@ export default defineComponent({
     const isCopiedType = computed<boolean>(() => props.alertType === AlertType.Copied);
     const { currentNetworkIdx } = useNetworkInfo();
     const isShiden = computed<boolean>(() => currentNetworkIdx.value === endpointKey.SHIDEN);
-
+    const isShibuya = computed<boolean>(() => currentNetworkIdx.value === endpointKey.SHIBUYA);
+    
     const goToSubscan = () => {
       if (!props.txHash) return;
 
       let rootName = 'astar';
       if (isShiden.value) {
         rootName = 'shiden';
+      } else if (isShibuya.value) {
+        rootName = 'shibuya';
       }
       const link = `https://${rootName}.subscan.io/extrinsic/${props.txHash}`;
       window.open(link, '_blank');


### PR DESCRIPTION
**Pull Request Summary**

Add support for [Shibuya Subscan](https://shibuya.subscan.io/) explorer link in success tx toast.

Currently, when clicking on "Check your transactions" in TX Success toast, it opens up `astar.subscan.io` instead of `shibuya.subscan.io` 

PS: not able to test due to captcha fails in localhost

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

- feat: add support for shibuya subscan links in tx success toast

**This pull request makes the following changes:**

**Adds**

- Add support for shibuya subcan in success tx toast.

- (ex: Fix validation function)

