### PR TITLE
fix: modified styling in the light client warning section for light theme

### DIFF
--- a/src/components/header/modals/ModalNetwork.vue
+++ b/src/components/header/modals/ModalNetwork.vue
@@ -271,21 +271,22 @@ export default defineComponent({
       }
     };
 
-    const randomizedEndpoint = (networkIdx: number) => {
+    const getRandomizedEndpoint = (endpointKey: endpointKey): string => {
+      const endpointsWithoutLightClient = providerEndpoints[endpointKey].endpoints.filter(
+        (it) => !checkIsLightClient(it.endpoint)
+      );
+      return getRandomFromArray(endpointsWithoutLightClient).endpoint;
+    };
+
+    const randomizedEndpoint = (networkIdx: number): void => {
       if (networkIdx === endpointKey.ASTAR) {
-        selEndpointAstar.value = getRandomFromArray(
-          providerEndpoints[endpointKey.ASTAR].endpoints
-        ).endpoint;
+        selEndpointAstar.value = getRandomizedEndpoint(endpointKey.ASTAR);
       }
       if (networkIdx === endpointKey.SHIDEN) {
-        selEndpointShiden.value = getRandomFromArray(
-          providerEndpoints[endpointKey.SHIDEN].endpoints
-        ).endpoint;
+        selEndpointShiden.value = getRandomizedEndpoint(endpointKey.SHIDEN);
       }
       if (networkIdx === endpointKey.SHIBUYA) {
-        selEndpointShibuya.value = getRandomFromArray(
-          providerEndpoints[endpointKey.SHIBUYA].endpoints
-        ).endpoint;
+        selEndpointShibuya.value = getRandomizedEndpoint(endpointKey.SHIBUYA);
       }
     };
 

--- a/src/components/header/modals/ModalNetwork.vue
+++ b/src/components/header/modals/ModalNetwork.vue
@@ -86,10 +86,12 @@
         </span>
         <ul v-if="isLightClientExtension" class="ul--warnings">
           <li>
-            <span>It might take a longer time to load data from chains</span>
+            <span>
+              {{ $t('drawer.takeLongerTimeToConnect') }}
+            </span>
           </li>
           <li>
-            <span>It might take a longer time or fail in sending transactions</span>
+            <span> {{ $t('drawer.takeLongerTimeToSend') }}</span>
           </li>
           <li v-if="selNetwork === endpointKey.SHIBUYA">
             <span>
@@ -134,7 +136,6 @@ import {
 import { ChainProvider, endpointKey, providerEndpoints } from 'src/config/chainEndpoints';
 import { LOCAL_STORAGE } from 'src/config/localStorage';
 import { getRandomFromArray, wait } from 'src/hooks/helper/common';
-import { stagingMainBranch } from 'src/links';
 import { buildNetworkUrl } from 'src/router/utils';
 import { useStore } from 'src/store';
 import { computed, defineComponent, ref, watch, onUnmounted } from 'vue';
@@ -377,4 +378,27 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @use 'src/components/header/styles/modal-network.scss';
+
+/* Memo: somehow these classes won't work in light theme if the classes defined on modal-network.scss  */
+.box--light-client-warning {
+  display: none;
+  @media (min-width: $sm) {
+    display: flex;
+    flex-direction: column;
+    row-gap: 8px;
+    margin-top: 24px;
+  }
+}
+
+.ul--warnings {
+  list-style: disc;
+  text-align: left;
+  padding-left: 24px;
+}
+
+.text--download {
+  display: block;
+  text-decoration: underline;
+  color: $astar-blue-dark;
+}
 </style>

--- a/src/components/header/styles/modal-network.scss
+++ b/src/components/header/styles/modal-network.scss
@@ -172,28 +172,6 @@
     border: 0px solid transparent;
   }
 
-  .box--light-client-warning {
-    display: none;
-    @media (min-width: $sm) {
-      display: flex;
-      flex-direction: column;
-      row-gap: 8px;
-      margin-top: 24px;
-    }
-  }
-
-  .ul--warnings {
-    list-style: disc;
-    text-align: left;
-    padding-left: 24px;
-  }
-
-  .text--download {
-    display: block;
-    text-decoration: underline;
-    color: $astar-blue-dark;
-  }
-
   .input--endpoint[type='radio'] {
     width: rem(16);
     height: rem(16);

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -117,6 +117,8 @@ export default {
     viaEndpoint: 'via {value}',
     lightClientWarning: 'Connecting via Light client is in beta. Use at your own risk.',
     shibuyaTakes20mins: 'It might take more than 20 mins to connect to Shibuya via Light client',
+    takeLongerTimeToConnect: 'It might take a longer time to load data from chains',
+    takeLongerTimeToSend: 'It might take a longer time or fail in sending transactions',
   },
   wallet: {
     connectWallet: 'Connect Wallet',


### PR DESCRIPTION
**Pull Request Summary**

* fix: modified styling in the light client warning section for light theme
* fix: avoids selecting the Light client endpoint randomly

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

* fix: modified styling in the light client warning section for light theme

**This pull request makes the following changes:**

**Fixes**
* fix: modified styling in the light client warning section for light theme
  * fixed a bug that some CSS classes didn't work properly on the component

=Before=
<img width="400px" src="https://user-images.githubusercontent.com/92044428/217138310-d5aac0b9-4327-4ebb-94bd-e6e34e127ae7.png"/>

<img width="400px" src="https://user-images.githubusercontent.com/92044428/217138436-4303cae9-9c6b-4917-818e-f6d27a304a03.png"/>

=After=

<img width="400px" src="https://user-images.githubusercontent.com/92044428/217138500-9e590d97-fe76-4f19-a159-a11230b7d6a1.png"/>


<img width="400px" src="https://user-images.githubusercontent.com/92044428/217138551-98f755b8-1c39-4b0c-ace1-5daf4e5b8430.png"/>