### PR TITLE
Improve “claim and restake”

### DIFF
--- a/src/components/dapp-staking/stake-manage/StakeForm.vue
+++ b/src/components/dapp-staking/stake-manage/StakeForm.vue
@@ -70,21 +70,14 @@
         :set-selected-gas="setSelectedTip"
       />
 
-      <div v-if="errMsg && currentAccount" class="row--box-error">
-        <div class="column--title">
-          <span class="text--dot">・</span>
-          <span class="color--white"> {{ $t(errMsg) }}</span>
-        </div>
-      </div>
       <div class="row--box-warning">
         <div class="column--title">
           <span class="text--dot">・</span>
           <span class="color--white"> {{ $t(warningMsg) }}</span>
         </div>
-        <!-- <div v-if="errMsg && currentAccount" class="column--title">
-          <span class="text--dot">・</span>
-          <span class="color--white"> {{ $t(errMsg) }}</span>
-        </div> -->
+      </div>
+      <div v-if="errMsg && currentAccount" class="row--box-error">
+        <span class="color--white"> {{ $t(errMsg) }}</span>
       </div>
       <div class="wrapper__row--button" :class="!errMsg && 'btn-margin-adjuster'">
         <astar-button

--- a/src/components/dapp-staking/stake-manage/StakeForm.vue
+++ b/src/components/dapp-staking/stake-manage/StakeForm.vue
@@ -70,19 +70,22 @@
         :set-selected-gas="setSelectedTip"
       />
 
+      <div v-if="errMsg && currentAccount" class="row--box-error">
+        <div class="column--title">
+          <span class="text--dot">・</span>
+          <span class="color--white"> {{ $t(errMsg) }}</span>
+        </div>
+      </div>
       <div class="row--box-warning">
         <div class="column--title">
           <span class="text--dot">・</span>
           <span class="color--white"> {{ $t(warningMsg) }}</span>
         </div>
-        <div v-if="errMsg && currentAccount" class="column--title">
+        <!-- <div v-if="errMsg && currentAccount" class="column--title">
           <span class="text--dot">・</span>
           <span class="color--white"> {{ $t(errMsg) }}</span>
-        </div>
+        </div> -->
       </div>
-      <!-- <div v-if="errMsg && currentAccount" class="row--box-error">
-        <span class="color--white"> {{ $t(errMsg) }}</span>
-      </div> -->
       <div class="wrapper__row--button" :class="!errMsg && 'btn-margin-adjuster'">
         <astar-button
           class="btn-size--confirm"

--- a/src/components/dapp-staking/stake-manage/StakeForm.vue
+++ b/src/components/dapp-staking/stake-manage/StakeForm.vue
@@ -111,7 +111,6 @@ import {
 import { getTokenImage } from 'src/modules/token';
 import { computed, defineComponent, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { BN } from '@polkadot/util';
 
 export default defineComponent({
   components: {

--- a/src/components/dapp-staking/stake-manage/StakeManage.vue
+++ b/src/components/dapp-staking/stake-manage/StakeManage.vue
@@ -59,7 +59,6 @@ import { Path } from 'src/router';
 import { useStore } from 'src/store';
 import { DappCombinedInfo } from 'src/v2/models';
 import { computed, defineComponent, ref, watch } from 'vue';
-import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
 export type StakeRightUi = 'information' | 'select-funds-from';

--- a/src/components/dapp-staking/stake-manage/StakeManage.vue
+++ b/src/components/dapp-staking/stake-manage/StakeManage.vue
@@ -76,8 +76,6 @@ export default defineComponent({
   setup() {
     const isModalSelectFunds = ref<boolean>(false);
     const rightUi = ref<StakeRightUi>('information');
-
-    const { t } = useI18n();
     const { screenSize, width } = useBreakpoints();
     const route = useRoute();
     useDappRedirect();

--- a/src/components/dapp-staking/stake-manage/styles/stake-form.scss
+++ b/src/components/dapp-staking/stake-manage/styles/stake-form.scss
@@ -43,6 +43,7 @@
   flex-direction: column;
   row-gap: 6px;
   padding: 8px 16px;
+  margin-bottom: 5px;
   border-radius: 6px;
   width: 344px;
   border: 1px solid $warning-red;
@@ -55,7 +56,6 @@
   display: flex;
   flex-direction: column;
   row-gap: 6px;
-  margin-bottom: 5px;
   border: 1px solid $border-yellow;
   padding: 8px 16px;
   width: 344px;

--- a/src/components/dapp-staking/stake-manage/styles/stake-form.scss
+++ b/src/components/dapp-staking/stake-manage/styles/stake-form.scss
@@ -42,9 +42,19 @@
   padding: 10px 20px;
   border-radius: 6px;
   width: 344px;
-  margin-bottom: 24px;
   border: 1px solid $warning-red;
   background: $box-red;
+  text-align: left;
+  @media (min-width: $sm) {
+    width: 412px;
+  }
+}
+.row--box-warning {
+  padding: 10px 20px;
+  border-radius: 6px;
+  width: 344px;
+  border: 1px solid $warning-yellow;
+  background: $warning-yellow;
   text-align: left;
   @media (min-width: $sm) {
     width: 412px;

--- a/src/components/dapp-staking/stake-manage/styles/stake-form.scss
+++ b/src/components/dapp-staking/stake-manage/styles/stake-form.scss
@@ -39,12 +39,14 @@
 }
 
 .row--box-error {
-  padding: 10px 20px;
+  display: flex;
+  flex-direction: column;
+  row-gap: 6px;
+  padding: 8px 16px;
   border-radius: 6px;
   width: 344px;
   border: 1px solid $warning-red;
   background: $box-red;
-  text-align: left;
   @media (min-width: $sm) {
     width: 412px;
   }
@@ -53,7 +55,7 @@
   display: flex;
   flex-direction: column;
   row-gap: 6px;
-  margin-bottom: 24px;
+  margin-bottom: 5px;
   border: 1px solid $border-yellow;
   padding: 8px 16px;
   width: 344px;
@@ -63,10 +65,14 @@
     width: 412px;
   }
 }
+.text--dot {
+  font-size: 24px;
+  font-weight: 700;
+}
 .column--title {
   display: flex;
   align-items: center;
-  column-gap: 16px;
+  column-gap: 10px;
 }
 
 .box__row {

--- a/src/components/dapp-staking/stake-manage/styles/stake-form.scss
+++ b/src/components/dapp-staking/stake-manage/styles/stake-form.scss
@@ -50,15 +50,23 @@
   }
 }
 .row--box-warning {
-  padding: 10px 20px;
-  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  row-gap: 6px;
+  margin-bottom: 24px;
+  border: 1px solid $border-yellow;
+  padding: 8px 16px;
   width: 344px;
-  border: 1px solid $warning-yellow;
-  background: $warning-yellow;
-  text-align: left;
+  border-radius: 6px;
+  background: $transparent-yellow;
   @media (min-width: $sm) {
     width: 412px;
   }
+}
+.column--title {
+  display: flex;
+  align-items: center;
+  column-gap: 16px;
 }
 
 .box__row {

--- a/src/hooks/useClaimAll.ts
+++ b/src/hooks/useClaimAll.ts
@@ -34,7 +34,7 @@ export function useClaimAll() {
   const { t } = useI18n();
   const { era } = useCurrentEra();
   const selectedAddress = computed(() => store.getters['general/selectedAddress']);
-  const { accountData, isLoadingBalance } = useBalance(selectedAddress);
+  const { accountData } = useBalance(selectedAddress);
   const { nativeTokenSymbol } = useNetworkInfo();
 
   const transferableBalance = computed(() => {
@@ -117,7 +117,6 @@ export function useClaimAll() {
     const transaction = api.tx.utility.batch(txsToExecute);
     const info = await api.tx.utility.batch(txsToExecute).paymentInfo(senderAddress.value);
     const partialFee = info.partialFee.toBn();
-    console.log('partialFee', partialFee.toString());
     const balance = new BN(
       ethers.utils.parseEther(transferableBalance.value.toString()).toString()
     );

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -315,6 +315,10 @@ export default {
         'The amount of token to be staking must be greater than {amount} {symbol}',
       allFundsWillBeTransferred:
         'All funds will be transferred because the min. staking amount is {minStakingAmount} {symbol}',
+      invalidBalance:
+        'Invalid balance to make a claim. Please add {symbol} tokens in to the account',
+      warningLeaveMinAmount:
+        'Account must hold greater than 10{symbol} in transferrable when you stake.',
     },
   },
   assets: {


### PR DESCRIPTION
**Pull Request Summary**

Improve “claim and restake”

- Add message on the warning notification to clarify when transferable balance doesn’t have enough balance to make claims. Invalid balance to make a claim. Please add ASTR tokens in to the account.
- When users select “Max” leave `10ASTR` in the account so it will keep the balance for longer period.
    - Add message before the confirm button on Staking page `Account must hold greater than 10ASTR in transferrable when you stake.`

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

fix: claim and restake issues

![스크린샷 2023-03-08 오후 12 19 55](https://user-images.githubusercontent.com/1606820/223621633-a424b8b9-63eb-4229-bd40-d6aa45659728.png)
![스크린샷 2023-03-08 오후 12 19 25](https://user-images.githubusercontent.com/1606820/223621653-6d008404-80ee-4890-9ae9-27c6aede40f0.png)

