### PR TITLE
fix: avoid browsers be crashed when users update the images

### DIFF
--- a/src/components/dapp-staking/register/RegisterDapp.vue
+++ b/src/components/dapp-staking/register/RegisterDapp.vue
@@ -19,7 +19,7 @@
           v-model="data.icon"
           outlined
           :label="$t('dappStaking.modals.projectLogo')"
-          accept=".jpg .png, image/*"
+          accept="image/jpeg, .png"
           class="component"
           input-style="{ height: '120px'}"
           lazy-rules="ondemand"
@@ -266,7 +266,7 @@ export default defineComponent({
             data.tags = registeredDapp.tags;
           }
         } else {
-          router.push(Path.DappStaking);
+          // router.push(Path.DappStaking);
         }
       } catch (e) {
         // TODO pop error message.
@@ -300,8 +300,8 @@ export default defineComponent({
           } as RegisterParameters);
 
           if (result) {
-            await router.push(Path.DappStaking);
-            router.go(0);
+            // await router.push(Path.DappStaking);
+            // router.go(0);
           }
         }
       });

--- a/src/components/dapp-staking/register/RegisterDapp.vue
+++ b/src/components/dapp-staking/register/RegisterDapp.vue
@@ -266,7 +266,7 @@ export default defineComponent({
             data.tags = registeredDapp.tags;
           }
         } else {
-          // router.push(Path.DappStaking);
+          router.push(Path.DappStaking);
         }
       } catch (e) {
         // TODO pop error message.
@@ -300,8 +300,8 @@ export default defineComponent({
           } as RegisterParameters);
 
           if (result) {
-            // await router.push(Path.DappStaking);
-            // router.go(0);
+            await router.push(Path.DappStaking);
+            router.go(0);
           }
         }
       });

--- a/src/components/dapp-staking/register/components/Builders.vue
+++ b/src/components/dapp-staking/register/components/Builders.vue
@@ -10,11 +10,11 @@
           v-for="(developer, index) in data.developers"
           :key="index"
           :description="developer.name"
+          :base64-image="developer.iconFile"
           :can-remove-card="true"
           @remove="removeDeveloper(index)"
           @click="editDeveloper(index)"
         >
-          <avatar :url="developer.iconFile" class="avatar" />
         </image-card>
         <image-card
           :description="$t('dappStaking.modals.addAccount')"
@@ -48,7 +48,6 @@ import ImageCard from './ImageCard.vue';
 import AddItemCard from './AddItemCard.vue';
 import ItemsContainer from './ItemsContainer.vue';
 import ModalAddDeveloper from './ModalAddDeveloper.vue';
-import Avatar from 'src/components/common/Avatar.vue';
 import { NewDappItem } from 'src/store/dapp-staking/state';
 import { Developer } from '@astar-network/astar-sdk-core';
 
@@ -56,7 +55,6 @@ export default defineComponent({
   components: {
     ItemsContainer,
     ImageCard,
-    Avatar,
     AddItemCard,
     ModalAddDeveloper,
   },

--- a/src/components/dapp-staking/register/components/Community.vue
+++ b/src/components/dapp-staking/register/components/Community.vue
@@ -14,7 +14,7 @@
           @remove="removeCommunity(index)"
           @click="editCommunity()"
         >
-          <avatar :icon-name="getCommunityIconName(community.type)" class="avatar" />
+          <avatar :icon-name="getCommunityIconName(community.type) as SocialIcon" class="avatar" />
         </image-card>
         <image-card description="Add an account" class="card">
           <add-item-card @click="addCommunity" />
@@ -171,6 +171,7 @@ export default defineComponent({
       addCommunity,
       handleModalAddCommunity,
       validateUrl,
+      SocialIcon,
     };
   },
 });

--- a/src/components/dapp-staking/register/components/DappImages.vue
+++ b/src/components/dapp-staking/register/components/DappImages.vue
@@ -6,7 +6,7 @@
       multiple
       append
       max-file-size="1000000"
-      accept=".jpg .png, image/*"
+      accept="image/jpeg, .png"
       :label="$t('dappStaking.modals.images')"
       class="component"
       lazy-rules="ondemand"

--- a/src/components/dapp-staking/register/components/DappImages.vue
+++ b/src/components/dapp-staking/register/components/DappImages.vue
@@ -7,7 +7,7 @@
       append
       max-file-size="1000000"
       accept="image/jpeg, .png"
-      :label="$t('dappStaking.modals.images')"
+      :label="$t('dappStaking.modals.images', { size: '1 MB' })"
       class="component"
       lazy-rules="ondemand"
       :rules="[(v: File[]) => (v && v.length >= 5) || $t('dappStaking.modals.imagesRequired')]"

--- a/src/components/dapp-staking/register/components/ModalAddDeveloper.vue
+++ b/src/components/dapp-staking/register/components/ModalAddDeveloper.vue
@@ -57,7 +57,7 @@
           outlined
           max-file-size="1000000"
           accept="image/jpeg, .png"
-          :label="$t('dappStaking.modals.builder.image')"
+          :label="$t('dappStaking.modals.builder.image', { size: '1MB' })"
           class="component"
           lazy-rules="ondemand"
           :rules="[(v: File) => v.size > 0 || `${$t('dappStaking.modals.builder.error.builderImageRequired')}`]"

--- a/src/components/dapp-staking/register/components/ModalAddDeveloper.vue
+++ b/src/components/dapp-staking/register/components/ModalAddDeveloper.vue
@@ -64,8 +64,11 @@
           @update:model-value="updateImage()"
         >
           <template #file>
-            <image-card v-show="currentDeveloper.iconFile" class="card">
-              <avatar :url="currentDeveloper.iconFile" class="avatar" />
+            <image-card
+              v-show="currentDeveloper.iconFile"
+              class="card"
+              :base64-image="currentDeveloper.iconFile"
+            >
             </image-card>
           </template>
         </q-file>
@@ -105,13 +108,11 @@ import { defineComponent, ref, toRefs, PropType, watch } from 'vue';
 import { fadeDuration } from '@astar-network/astar-ui';
 import { isUrlValid } from 'src/components/common/Validators';
 import ImageCard from './ImageCard.vue';
-import Avatar from 'src/components/common/Avatar.vue';
 import ModalWrapper from 'src/components/common/ModalWrapper.vue';
 
 export default defineComponent({
   components: {
     ImageCard,
-    Avatar,
     ModalWrapper,
   },
   props: {

--- a/src/components/dapp-staking/register/components/ModalAddDeveloper.vue
+++ b/src/components/dapp-staking/register/components/ModalAddDeveloper.vue
@@ -56,7 +56,7 @@
           v-model="file"
           outlined
           max-file-size="1000000"
-          accept=".jpg .png, image/*"
+          accept="image/jpeg, .png"
           :label="$t('dappStaking.modals.builder.image')"
           class="component"
           lazy-rules="ondemand"

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -257,7 +257,7 @@ export default {
         githubAccount: 'GitHub account',
         twitterAccount: 'Twitter account',
         linkedInAccount: 'LinkedIn account',
-        image: "Builder's image",
+        image: "Builder's image (maximum upload file size: {size})",
         imageRecomendation: 'A square image of minimum 500px is recommended.',
         error: {
           name: 'Builder name is required.',
@@ -288,7 +288,7 @@ export default {
       addAccount: 'Add an account',
       addLogo: 'Add a logo image',
       addImage: 'Add an image',
-      images: 'Images',
+      images: 'Images (maximum upload file size: {size})',
       imagesRequired: 'At least 4 images are required.',
       descriptionRequired: 'Tell the world something about your dApp.',
       contractTypeTitle: 'Is your project on',


### PR DESCRIPTION
**Pull Request Summary**

* fix: avoid browsers be crashed when users update the images
* feat: added maximum file size text

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

* fix: avoid browsers be crashed when users update the images

**This pull request makes the following changes:**

**Fixes**

* fix: avoid browsers be crashed when users update the images
  * demo: https://www.loom.com/share/18766218a15e40b2a965eb3b622219b9  

* feat: added maximum file size text
![image](https://user-images.githubusercontent.com/92044428/226527146-9a4a59fd-6b00-4692-83ba-2503d7a24e93.png)
