### PR TITLE
feat: disabled XCM transfer with Kusama parachains

### DIFF
--- a/src/components/assets/transfer/Transfer.vue
+++ b/src/components/assets/transfer/Transfer.vue
@@ -125,6 +125,7 @@ export default defineComponent({
       chains,
       tokens,
       isLocalTransfer,
+      isDisableXcmEnvironment,
       setIsLocalTransfer,
       setToken,
       setChain,
@@ -143,7 +144,9 @@ export default defineComponent({
       const isEvmNativeToken =
         isH160.value && tokenSymbol.value === nativeTokenSymbol.value.toLowerCase();
       const isXcmCompatible = token.value?.isXcmCompatible;
-      return isShibuya.value || isEvmNativeToken || !isXcmCompatible;
+      return (
+        isShibuya.value || isEvmNativeToken || !isXcmCompatible || isDisableXcmEnvironment.value
+      );
     });
 
     const isTransferNativeToken = computed<boolean>(() => {

--- a/src/hooks/xcm/useTransferRouter.ts
+++ b/src/hooks/xcm/useTransferRouter.ts
@@ -17,11 +17,15 @@ import { computed, ref, watch, watchEffect } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { EvmAssets, XcmAssets } from 'src/store/assets/state';
 import { capitalize } from '@astar-network/astar-sdk-core';
+import { Path } from 'src/router';
+import { productionOrigin } from 'src/links';
 
 export const pathEvm = '-evm';
 export type TransferMode = 'local' | 'xcm';
 export const astarNetworks = ['astar', 'shiden', 'shibuya'];
 export const astarNativeTokens = ['sdn', 'astr', 'sby'];
+const disabledXcmChain = endpointKey.SHIDEN;
+
 export interface NetworkFromTo {
   from: string;
   to: string;
@@ -344,10 +348,24 @@ export function useTransferRouter() {
     }
   };
 
+  const isDisableXcmEnvironment = computed<boolean>(() => {
+    const isProductionPage = window.location.origin === productionOrigin;
+    const isDisabledXcmChain = disabledXcmChain === currentNetworkIdx.value;
+    return isDisabledXcmChain && isProductionPage;
+  });
+
+  // Memo: route to assets page if users open the XCM transfer page by inputting URL directly
+  const handleDisableXcmTransfer = (): void => {
+    if (isDisableXcmEnvironment.value && mode.value === 'xcm') {
+      router.push(Path.Assets);
+    }
+  };
+
   watchEffect(handleDefaultConfig);
   watchEffect(monitorProhibitedPair);
   watch([currentAccount, isH160, xcmAssets], handleIsFoundToken, { immediate: false });
   watchEffect(setNativeTokenBalance);
+  watchEffect(handleDisableXcmTransfer);
 
   return {
     tokenSymbol,
@@ -364,6 +382,7 @@ export function useTransferRouter() {
     token,
     tokens,
     chains,
+    isDisableXcmEnvironment,
     redirect,
     reverseChain,
     getFromToParams,

--- a/src/hooks/xcm/useTransferRouter.ts
+++ b/src/hooks/xcm/useTransferRouter.ts
@@ -354,7 +354,7 @@ export function useTransferRouter() {
     return isDisabledXcmChain && isProductionPage;
   });
 
-  // Memo: route to assets page if users open the XCM transfer page by inputting URL directly
+  // Memo: redirect to the assets page if users access to the XCM transfer page by inputting URL directly
   const handleDisableXcmTransfer = (): void => {
     if (isDisableXcmEnvironment.value && mode.value === 'xcm') {
       router.push(Path.Assets);

--- a/src/links/index.ts
+++ b/src/links/index.ts
@@ -24,8 +24,7 @@ export const deepLink = {
 };
 
 export const stagingOrigin = 'https://staging.portal.astar.network';
-// export const productionOrigin = 'https://portal.astar.network';
-export const productionOrigin = 'https://astar-apps--pr723-feat-disable-xcm-kus-tcsj8286.web.app';
+export const productionOrigin = 'https://portal.astar.network';
 
 export const polkadotJsUrl = {
   settings: {

--- a/src/links/index.ts
+++ b/src/links/index.ts
@@ -24,7 +24,8 @@ export const deepLink = {
 };
 
 export const stagingOrigin = 'https://staging.portal.astar.network';
-export const productionOrigin = '"https://portal.astar.network"';
+// export const productionOrigin = 'https://portal.astar.network';
+export const productionOrigin = 'https://astar-apps--pr723-feat-disable-xcm-kus-tcsj8286.web.app';
 
 export const polkadotJsUrl = {
   settings: {

--- a/src/links/index.ts
+++ b/src/links/index.ts
@@ -23,7 +23,8 @@ export const deepLink = {
   metamask: `https://metamask.app.link/dapp/${window.location.host}/${deepLinkPath.metamask}`,
 };
 
-export const stagingMainBranch = 'https://staging.portal.astar.network';
+export const stagingOrigin = 'https://staging.portal.astar.network';
+export const productionOrigin = '"https://portal.astar.network"';
 
 export const polkadotJsUrl = {
   settings: {


### PR DESCRIPTION
**Pull Request Summary**

* feat: disabled XCM transafer with Kusama parachains
  * disables the XCM transfer with Kusama parachains as Kusama is going to upgrade to XCM V3 on 4-Apr
  * disables the XCM transfer at production URL (https://portal.astar.network/shiden) only. Anyone still can test it at the staging URL 

**To-dos**
* Merge this PR and update the production page on 3-Apr

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

* feat: disables XCM transafer with Kusama parachains

**This pull request makes the following changes:**

**Changes**

![image](https://user-images.githubusercontent.com/92044428/228431903-9c990860-225c-485a-809c-5a323e597cd1.png)

![image](https://user-images.githubusercontent.com/92044428/228432186-8dc1a77d-237b-455a-86f3-3052cec4b24d.png)