### PR TITLE
Fix not visible on unbonding tab

### DIFF
--- a/src/hooks/dapps-staking/useUnbonding.ts
+++ b/src/hooks/dapps-staking/useUnbonding.ts
@@ -92,7 +92,7 @@ export function useUnbonding() {
   };
 
   watch(
-    () => unlockingChunksCount.value,
+    () => [unlockingChunksCount.value, selectedAccountAddress.value],
     async (chunks) => {
       // console.log('chunks count changed');
       const era = await $api?.query.dappsStaking.currentEra<u32>();


### PR DESCRIPTION
**Pull Request Summary**

Fix not visible on unbonding tab

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

To reproduce:
Start with Asset page
Go to staking page. This time, you will see the unbonding tab.
Refresh the staking page, unbonding tab is missing. Refreshing again also does not bring the unbonding tab.
Go to Asset page and go back to staking page, you will see the unbonding tab.