### PR TITLE
fix: avoid loading the portal twice on the first visit

### DIFF
--- a/src/hooks/useAppRouter.ts
+++ b/src/hooks/useAppRouter.ts
@@ -56,6 +56,8 @@ export function useAppRouter() {
       );
       localStorage.setItem(NETWORK_IDX, endpointIdx);
       if (network.value === networkParam) {
+        // Memo: Avoid loading the portal for browsers visiting the portal for the first time.
+        // Reload when users input the networks on the address bar manually.
         !isFirstTimeVisitor && window.location.reload();
       } else {
         const redirectNetwork =

--- a/src/hooks/useAppRouter.ts
+++ b/src/hooks/useAppRouter.ts
@@ -48,13 +48,15 @@ export function useAppRouter() {
       networkIdxStore === undefined ||
       storedNetworkAlias !== networkParam;
     if (isReload) {
+      // Memo: `defaultCurrency` and `selectedEndpoint` are updated when the app connects to the API
+      const isFirstTimeVisitor = localStorage.length === 2;
       localStorage.setItem(
         SELECTED_ENDPOINT,
         JSON.stringify({ [endpointIdx]: selectedChain.endpoints[0].endpoint })
       );
       localStorage.setItem(NETWORK_IDX, endpointIdx);
       if (network.value === networkParam) {
-        window.location.reload();
+        !isFirstTimeVisitor && window.location.reload();
       } else {
         const redirectNetwork =
           network.value.toLowerCase() === 'shibuya' ? endpointKey.SHIBUYA : endpointKey.ASTAR;

--- a/src/hooks/useAppRouter.ts
+++ b/src/hooks/useAppRouter.ts
@@ -56,8 +56,8 @@ export function useAppRouter() {
       );
       localStorage.setItem(NETWORK_IDX, endpointIdx);
       if (network.value === networkParam) {
-        // Memo: Avoid loading the portal for browsers visiting the portal for the first time.
-        // Reload when users input the networks on the address bar manually.
+        // Memo: Avoid loading the portal twice on the first visit
+        // Reload when users input the networks on the address bar manually
         !isFirstTimeVisitor && window.location.reload();
       } else {
         const redirectNetwork =


### PR DESCRIPTION
**Pull Request Summary**

* fix: avoid loading the portal twice on the first visit

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

* fix: avoid loading the portal twice on the first visit

**This pull request makes the following changes:**

**Fixes**

=Before=
https://i.gyazo.com/adce398cda4191f9ff655c9d0e73ea6c.mp4

=After=
https://www.loom.com/share/881347f0e2a74cd89fd8ee8a7109aef2