### PR TITLE
Don't set Ethereum Extension value to currentAddress field

### DIFF
--- a/src/hooks/useClaimAll.ts
+++ b/src/hooks/useClaimAll.ts
@@ -15,7 +15,6 @@ import { IDappStakingService } from 'src/v2/services';
 import { Symbols } from 'src/v2/symbols';
 import { ethers } from 'ethers';
 import { computed, ref, watchEffect } from 'vue';
-import { useNetworkInfo } from 'src/hooks';
 import { useI18n } from 'vue-i18n';
 
 const MAX_BATCH_WEIGHT = new BN('50000000000');
@@ -33,9 +32,7 @@ export function useClaimAll() {
   const isSendingTx = computed(() => store.getters['general/isLoading']);
   const { t } = useI18n();
   const { era } = useCurrentEra();
-  const selectedAddress = computed(() => store.getters['general/selectedAddress']);
-  const { accountData } = useBalance(selectedAddress);
-  const { nativeTokenSymbol } = useNetworkInfo();
+  const { accountData } = useBalance(senderAddress);
 
   const transferableBalance = computed(() => {
     const balance = accountData.value

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -290,8 +290,9 @@ export const useConnectWallet = () => {
       }
 
       await setEvmWallet(wallet as SupportWallet);
+    } else {
+      store.commit('general/setCurrentAddress', address);
     }
-    store.commit('general/setCurrentAddress', address);
   };
 
   const changeAccount = async (): Promise<void> => {


### PR DESCRIPTION
**Pull Request Summary**

This PR is to fix issue with using dApps staking with lockdrop accounts.

The root cause of the issue is that `currentAddress` is incorrectly set. `currentAddress` should have the same value as `ss58` field (edited) 
![image](https://user-images.githubusercontent.com/8452361/231463716-10d4197b-c2b1-4558-ac25-fe3b257e5986.png)

I disabled setting 'Ethereum Extension' value to the `currentAddress` field. I am not sure why we are storing such invalid value to Vuex. Also, not sure if this change breaks something else, so serious testing is required.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

- Fixed dApps staking not working with Lockdrop accounts issue.
