### PR TITLE
Fixed claim tooltip text

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -195,7 +195,7 @@ export default {
     availableToClaimTip:
       'The amount of unclaimed rewards is estimated and there may be a small difference between what is shown and what you actually receive.',
     availableToClaimTip2:
-      'The number of eras that is shown here is per dApp. The maximum number of eras you can claim at once is 50. You may need to claim multiple times if you leave it too long.',
+      'The number of eras that is shown here is per dApp. You may need to claim multiple times if you have too many unclaimed eras.',
     restakeTip:
       'By turning on, your rewards will be automatically re-staked when you make a claim.',
   },


### PR DESCRIPTION
**Pull Request Summary**

Updated claim tooltip text to be less confusing. Please comment if you find it more confusing now :)
Actually, information about 50 eras claimed in one batch is incorrect. We are filling claim batch until some weight is reached. Number of transaction per batch depends on transactions weight and it varies.

Related to #742 


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

- Claim reward tooltip message update
