### PR TITLE
Fix total dApps count

### DIFF
--- a/src/components/dapp-staking/my-staking/TopMetric.vue
+++ b/src/components/dapp-staking/my-staking/TopMetric.vue
@@ -110,7 +110,7 @@ import {
 import { formatNumber } from '@astar-network/astar-sdk-core';
 import { useStore } from 'src/store';
 import { TvlModel } from 'src/v2/models';
-import { DappCombinedInfo } from 'src/v2/models/DappsStaking';
+import { DappCombinedInfo, SmartContractState } from 'src/v2/models/DappsStaking';
 import { computed, defineComponent, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import PieChart from 'src/components/common/PieChart.vue';
@@ -121,8 +121,11 @@ export default defineComponent({
     const store = useStore();
     const { stakerApr, stakerApy } = useAprFromApi();
     const { currentAccount } = useAccount();
-    const dappsCount = computed<DappCombinedInfo[]>(
-      () => store.getters['dapps/getRegisteredDapps']().length
+    const dappsCount = computed<number>(
+      () =>
+        store.getters['dapps/getRegisteredDapps']().filter(
+          (x: DappCombinedInfo) => x.contract.state === SmartContractState.Registered
+        ).length
     );
     const currentBlock = computed<number>(() => store.getters['general/getCurrentBlock']);
     const currentEra = computed<number>(() => store.getters['dapps/getCurrentEra']);


### PR DESCRIPTION
**Pull Request Summary**

Fix for invalid number of dApps displayed on the portal. The problem was that unregistered dApps were also counted.

BEFORE
![image](https://user-images.githubusercontent.com/8452361/233951564-2b5c3bce-61e6-46b6-a0a6-93ed22988a76.png)

AFTER
<img width="185" alt="image" src="https://user-images.githubusercontent.com/8452361/233951730-19fb3a34-a4e8-40a6-af72-baac5969a4b0.png">


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

- Fix: invalid total number of dApps shown on dApps staking page

