### PR TITLE
Fix: Use XcmV2WeightLimit in InterlayXcmRepository.ts

### DIFF
--- a/src/v2/repositories/implementations/xcm/InterlayXcmRepository.ts
+++ b/src/v2/repositories/implementations/xcm/InterlayXcmRepository.ts
@@ -54,7 +54,9 @@ export class InterlayXcmRepository extends XcmRepository {
       },
     };
 
-    const destWeight = new BN(10).pow(new BN(9)).muln(5);
+    const destWeight = {
+      limited: new BN(10).pow(new BN(9)).muln(5),
+    };
     return await this.buildTxCall(
       from,
       'xTokens',


### PR DESCRIPTION
**Pull Request Summary**

> Use XcmV2WeightLimit format for Interlay xcm transfers.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**Release notes:**

- fix: use XcmV2WeightLimit in for Interlay XCM transfers 

**This pull request makes the following changes:**

**Fixes**

- Fixes the XCM error users see when they try to submit an `xTokens.transfer` extrinsic
