### PR TITLE
Fix unbonding tab shown after unbonded transactions

### DIFF
--- a/src/hooks/dapps-staking/useUnbond.ts
+++ b/src/hooks/dapps-staking/useUnbond.ts
@@ -13,6 +13,7 @@ export function useUnbound() {
   const store = useStore();
   const { currentAccount } = useAccount();
   const unbondingPeriod = computed(() => store.getters['dapps/getUnbondingPeriod']);
+  const selectedAccountAddress = computed(() => store.getters['general/selectedAddress']);
   const { t } = useI18n();
 
   const handleUnbound = async (contractAddress: string, amount: string | null): Promise<void> => {
@@ -28,6 +29,9 @@ export function useUnbound() {
         unbondAmount,
         successMessage
       );
+
+      const ledger = await dappStakingService.getLedger(selectedAccountAddress.value);
+      store.commit('dapps/setUnlockingChunks', ledger.unbondingInfo.unlockingChunks);
     }
   };
 

--- a/src/hooks/dapps-staking/useUnbonding.ts
+++ b/src/hooks/dapps-staking/useUnbonding.ts
@@ -94,7 +94,7 @@ export function useUnbonding() {
   watch(
     () => [unlockingChunksCount.value, selectedAccountAddress.value],
     async (chunks) => {
-      // console.log('chunks count changed');
+      console.log('chunks count changed');
       const era = await $api?.query.dappsStaking.currentEra<u32>();
       if (era) {
         await getChunks(era);

--- a/src/hooks/dapps-staking/useUnbonding.ts
+++ b/src/hooks/dapps-staking/useUnbonding.ts
@@ -94,7 +94,7 @@ export function useUnbonding() {
   watch(
     () => [unlockingChunksCount.value, selectedAccountAddress.value],
     async (chunks) => {
-      console.log('chunks count changed');
+      // console.log('chunks count changed');
       const era = await $api?.query.dappsStaking.currentEra<u32>();
       if (era) {
         await getChunks(era);


### PR DESCRIPTION
**Pull Request Summary**

The portal doesn’t show Unbonding tab after sending unbond transactions.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices


https://github.com/AstarNetwork/astar-apps/assets/1606820/1252357d-8267-4a3d-81c6-b509b66432de

