### PR TITLE
fix: dappstaking transaction.spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "heroku-postbuild": "yarn install && yarn build",
     "heroku-deploy": "git push heroku main",
     "playwright:codegen": "npx playwright codegen http://localhost:8080",
-    "playwright": "BASE_URL='http://localhost:8080' npx playwright test --project=chromium --debug",
+    "playwright": "BASE_URL='http://localhost:8080' ENDPOINT='ws://127.0.0.1:8000' npx playwright test --project=chromium --debug",
     "playwright:ci": "node ./tests/chopsticks/start-chopsticks.js"
   },
   "dependencies": {

--- a/tests/dappstaking-transactions.spec.ts
+++ b/tests/dappstaking-transactions.spec.ts
@@ -19,7 +19,8 @@ import {
   setRewardDestination,
 } from './common-api';
 
-const TEST_DAPP_ADDRESS = '0x0000000000000000000000000000000000000001';
+// Memo: Astar Core Contributors
+const TEST_DAPP_ADDRESS = '0xa602d021da61ec4cc44dedbd4e3090a05c97a435';
 
 const stake = async (page: Page, context: BrowserContext, amount: bigint): Promise<void> => {
   await page.goto(`/custom-node/dapp-staking/stake?dapp=${TEST_DAPP_ADDRESS}`);

--- a/tests/dappstaking-transactions.spec.ts
+++ b/tests/dappstaking-transactions.spec.ts
@@ -170,13 +170,4 @@ test.describe('dApp staking transactions', () => {
     const newPage = await context.waitForEvent('page');
     await expect(newPage).toHaveURL(/twitter/);
   });
-
-  // Test case: DS007
-  test('Twitter share button works', async ({ page, context }) => {
-    await page.goto(`/custom-node/dapp-staking/dapp?dapp=${TEST_DAPP_ADDRESS}`);
-    await selectAccount(page, ALICE_ACCOUNT_NAME);
-    await page.getByRole('link', { name: 'Twitter icon Share' }).click();
-    const newPage = await context.waitForEvent('page');
-    await expect(newPage).toHaveURL(/twitter/);
-  });
 });


### PR DESCRIPTION
**Pull Request Summary**

* fix: dappstaking transaction.spec
  * fixed DS001, DS002, and DS007
    * DS007: duplicated 
    * DS001, DS002: now that the tests are using chopsticks so that chopsticks fork the actual Astar network, therefore, the test code has to use the actual dApp address instead of '0x0000000000000000000000000000000000000001'.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Adds**

- (ex: Add feature A)

**Fixes**

- (ex: Fix validation function)

**Changes**

- (ex: Change document B)

**To-dos**

> \*Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)
