### PR TITLE
Remove the subtitle from IPFS banner

### DIFF
--- a/src/data/dynamic_links.json
+++ b/src/data/dynamic_links.json
@@ -1,7 +1,7 @@
 [
     {
       "title": "links.goDecentralized",
-      "subtitle": "links.portalIpfs",
+      "subtitle": "",
       "link": "https://decentralized.portal.astar.network"
     },
     {


### PR DESCRIPTION
**Pull Request Summary**

Remove the subtitle “portal is now on IPFS” from a banner on Asset page

| BEFORE | AFTER |
|---------|---------|
|<img width="310" alt="Screenshot 2023-07-13 at 9 27 18 AM" src="https://github.com/AstarNetwork/astar-apps/assets/33358068/a968fff5-206e-41f2-ba87-c2d753d5c6c2">|<img width="313" alt="Screenshot 2023-07-13 at 9 26 52 AM" src="https://github.com/AstarNetwork/astar-apps/assets/33358068/56d2c3e7-17fa-41d0-990e-adbd0dad1316">|

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**

- Only changed src/data/dynamic_links.json file