### PR TITLE
PR Action trigger changed

### DIFF
--- a/.github/workflows/pull-request-preview.yml
+++ b/.github/workflows/pull-request-preview.yml
@@ -3,7 +3,7 @@
 
 name: Create Firebase Hosting Preview on PR
 on:
-  pull_request:
+  pull_request_target:
     inputs:
       astar_tag:
         description: 'Release tag version for astar collator'


### PR DESCRIPTION
**Pull Request Summary**

Because PRs created with Dependabot doesn't have access to GH secrets
https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/ 


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

