### PR TITLE
fix: display select-able account on ‘Account Drawer’ after granting authorisation on wallet extensions

### DIFF
--- a/src/components/header/modals/ModalAccount.vue
+++ b/src/components/header/modals/ModalAccount.vue
@@ -146,8 +146,6 @@ import { useStore } from 'src/store';
 import { SubstrateAccount } from 'src/store/general/state';
 import { computed, defineComponent, PropType, ref, watch, onUnmounted, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useExtensions } from 'src/hooks/useExtensions';
-import { useMetaExtensions } from 'src/hooks/useMetaExtensions';
 import { useBreakpoints, useNetworkInfo } from 'src/hooks';
 import { Ledger } from '@polkadot/hw-ledger';
 import { astarChain } from 'src/config/chain';

--- a/src/components/header/modals/ModalAccount.vue
+++ b/src/components/header/modals/ModalAccount.vue
@@ -328,14 +328,6 @@ export default defineComponent({
       { immediate: true }
     );
 
-    const requestExtensionsIfFirstAccess = (): void => {
-      // Memo: displays wallet's authorization popup
-      const { extensions } = useExtensions($api!!, store);
-      const { metaExtensions, extensionCount } = useMetaExtensions($api!!, extensions)!!;
-      store.commit('general/setMetaExtensions', metaExtensions.value);
-      store.commit('general/setExtensionCount', extensionCount.value);
-    };
-
     const updateIsLedgerAccount = async (isLedger: boolean): Promise<void> => {
       localStorage.setItem(LOCAL_STORAGE.IS_LEDGER, isLedger.toString());
       store.commit('general/setIsLedger', isLedger);
@@ -377,8 +369,6 @@ export default defineComponent({
       }
     };
 
-    watch([props.selectedWallet], requestExtensionsIfFirstAccess, { immediate: true });
-
     watch([selAccount], () => {
       toggleIsLedger.value = false;
     });
@@ -399,6 +389,10 @@ export default defineComponent({
 
     onUnmounted(() => {
       window.removeEventListener('resize', onHeightChange);
+    });
+
+    watchEffect(() => {
+      console.log('substrateAccountsAll', substrateAccountsAll.value);
     });
 
     return {

--- a/src/components/header/modals/ModalAccount.vue
+++ b/src/components/header/modals/ModalAccount.vue
@@ -391,10 +391,6 @@ export default defineComponent({
       window.removeEventListener('resize', onHeightChange);
     });
 
-    watchEffect(() => {
-      console.log('substrateAccountsAll', substrateAccountsAll.value);
-    });
-
     return {
       selAccount,
       closeModal,

--- a/src/components/header/modals/ModalConnectWallet.vue
+++ b/src/components/header/modals/ModalConnectWallet.vue
@@ -124,50 +124,6 @@
             </div>
           </div>
         </div>
-        <div v-if="selWallet && isNoExtension" class="box--no-extension">
-          <div class="title--no-extension">
-            <span class="text--install-title">
-              {{ $t('installWallet.getWallet', { value: $t(selWallet.name) }) }}
-            </span>
-          </div>
-          <div class="row--no-extension">
-            <span class="text--install">
-              {{ $t('installWallet.installWallet', { value: $t(selWallet.name) }) }}</span
-            >
-          </div>
-          <div class="row--icon-links">
-            <button>
-              <a
-                :href="selWallet.walletUrl"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="button--link"
-              >
-                <div class="icon--link">
-                  <astar-icon-external-link />
-                </div>
-                <span class="text--install-link">
-                  {{ $t('installWallet.install') }}
-                </span>
-              </a>
-            </button>
-            <button>
-              <a
-                :href="selWallet.guideUrl"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="button--link"
-              >
-                <div class="icon--link">
-                  <astar-icon-external-link />
-                </div>
-                <span class="text--install-link">
-                  {{ $t('installWallet.learn') }}
-                </span>
-              </a>
-            </button>
-          </div>
-        </div>
       </div>
       <button :disabled="!currentAccountName" class="btn--disconnect" @click="disconnectAccount()">
         {{ $t('disconnect') }}


### PR DESCRIPTION
**Pull Request Summary**

* fix: display select-able account on ‘Account Drawer’ after granting authorisation on wallet extensions(for first time visitors)
  * removed duplicated `requestExtensionsIfFirstAccess` function which is the same function called in another hooks prior to open`ModalAccount.ts`   

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**
=Before=
![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/7e9ac3de-2f00-4be0-91db-075ecf602fa6)


=After=
![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/b5c82c16-8a5d-42b4-97a7-5e7bf67d9a48)
