### PR TITLE
hotfix: open My Rewards tab as default for EVM wallets on dApp staking page

### DIFF
--- a/src/components/dapp-staking/my-staking/MyStaking.vue
+++ b/src/components/dapp-staking/my-staking/MyStaking.vue
@@ -89,7 +89,7 @@ export default defineComponent({
     const { nativeTokenSymbol } = useNetworkInfo();
     const { unlockingChunks } = useUnbonding();
     const { myStakeInfos } = useStakerInfo();
-    const { currentAccount } = useAccount();
+    const { senderSs58Account } = useAccount();
 
     const selectedAddress = computed(() => store.getters['general/selectedAddress']);
     const { accountData, isLoadingBalance } = useBalance(selectedAddress);
@@ -102,7 +102,7 @@ export default defineComponent({
     });
 
     watch(
-      [currentAccount],
+      [senderSs58Account],
       () => {
         currentTab.value = MyStakingTab.MyRewards;
       },

--- a/src/components/dapp-staking/my-staking/MyStaking.vue
+++ b/src/components/dapp-staking/my-staking/MyStaking.vue
@@ -106,7 +106,7 @@ export default defineComponent({
       () => {
         currentTab.value = MyStakingTab.MyRewards;
       },
-      { immediate: false }
+      { immediate: true }
     );
 
     return {


### PR DESCRIPTION
**Pull Request Summary**

* hotfix: open My Rewards tab as default for EVM wallets on dApp staking page

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**
=Before=
<img width="1323" alt="image" src="https://github.com/AstarNetwork/astar-apps/assets/92044428/e18ce4f6-a8d3-447a-870c-97e6bead80b4">

=After=

<img width="1328" alt="image" src="https://github.com/AstarNetwork/astar-apps/assets/92044428/84f615c7-83bb-4714-bbf3-aaab5e5e5e21">
