### PR TITLE
Native asset transfer support for unified accounts

### DIFF
--- a/src/components/assets/Assets.vue
+++ b/src/components/assets/Assets.vue
@@ -193,8 +193,9 @@ export default defineComponent({
     // Temp set identity test, TODO remove later
     const setIdentity = async () => {
       const tokenOwnerAddress = '0xe42A2ADF3BEe1c195f4D72410421ad7908388A6a';
-      const nftRepository = container.get<INftRepository>(Symbols.BluezNftRepository);
+      const nftRepository = container.get<INftRepository>(Symbols.NftRepository);
       const nfts = await nftRepository.getNftMetadata(
+        'astar',
         '0x7b2152e51130439374672af463b735a59a47ea85',
         '8893zß'
       );

--- a/src/hooks/transfer/useTokenTransfer.ts
+++ b/src/hooks/transfer/useTokenTransfer.ts
@@ -7,7 +7,6 @@ import {
   isValidAddressPolkadotAddress,
   isValidEvmAddress,
   sampleEvmWalletAddress,
-  toSS58Address,
 } from '@astar-network/astar-sdk-core';
 import { $api, $web3 } from 'boot/api';
 import { ethers } from 'ethers';
@@ -37,7 +36,7 @@ export function useTokenTransfer(selectedToken: Ref<Asset>) {
 
   const store = useStore();
   const { t } = useI18n();
-  const { currentAccount } = useAccount();
+  const { currentAccount, getSS58Address } = useAccount();
   const { accountData } = useBalance(currentAccount);
 
   const transferableBalance = computed<number>(() => {
@@ -193,7 +192,7 @@ export function useTokenTransfer(selectedToken: Ref<Asset>) {
         });
       } else {
         const receivingAddress = isValidEvmAddress(toAddress)
-          ? toSS58Address(toAddress)
+          ? await getSS58Address(toAddress)
           : toAddress;
         const successMessage = t('assets.toast.completedMessage', {
           symbol,
@@ -241,7 +240,7 @@ export function useTokenTransfer(selectedToken: Ref<Asset>) {
     }
 
     const isSendToH160 = isValidEvmAddress(toAddress.value);
-    const destAddress = isSendToH160 ? toSS58Address(toAddress.value) : toAddress.value;
+    const destAddress = isSendToH160 ? await getSS58Address(toAddress.value) : toAddress.value;
     const srcChainId = evmNetworkIdx.value;
 
     if (isTransferNativeToken.value) {

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -3,7 +3,7 @@ import { LOCAL_STORAGE } from 'src/config/localStorage';
 import { SupportMultisig } from 'src/config/wallets';
 import { Multisig } from 'src/modules/multisig';
 import { useStore } from 'src/store';
-import { SubstrateAccount } from 'src/store/general/state';
+import { SubstrateAccount, UnifiedAccount } from 'src/store/general/state';
 import { container } from 'src/v2/common';
 import { IAccountUnificationService } from 'src/v2/services';
 import { Symbols } from 'src/v2/symbols';
@@ -26,8 +26,11 @@ export const useAccount = () => {
 
   // Memo: converts EVM wallet address to SS58 for dApp staking queries
   const senderSs58Account = computed<string>(() => {
+    const unifiedAccount = store.getters['general/getUnifiedAccount'] as UnifiedAccount;
     return isValidEvmAddress(currentAccount.value)
-      ? toSS58Address(currentAccount.value)
+      ? unifiedAccount
+        ? unifiedAccount.SS58Address
+        : toSS58Address(currentAccount.value)
       : currentAccount.value;
   });
   const isMultisig = computed<boolean>(() => !!localStorage.getItem(LOCAL_STORAGE.MULTISIG));

--- a/src/store/general/getters.ts
+++ b/src/store/general/getters.ts
@@ -7,6 +7,7 @@ import {
   AlertBox,
   EcdsaAccount,
   SubstrateAccount,
+  UnifiedAccount,
 } from './state';
 import type { ChainInfo } from 'src/hooks/useChainInfo';
 import type { Extensions } from 'src/hooks/useMetaExtensions';
@@ -33,6 +34,7 @@ export interface GeneralGetters {
   currentWallet(state: State): string;
   getGas(state: State): GasTip | undefined;
   getCurrentBlock(state: State): number;
+  getUnifiedAccount(state: State): UnifiedAccount | undefined;
 }
 
 const getters: GetterTree<State, StateInterface> & GeneralGetters = {
@@ -59,6 +61,7 @@ const getters: GetterTree<State, StateInterface> & GeneralGetters = {
   currentWallet: (state: State) => state.currentWallet,
   getGas: (state: State) => state.gas,
   getCurrentBlock: (state: State) => state.currentBlock,
+  getUnifiedAccount: (state: State) => state.unifiedAccount,
 };
 
 export default getters;

--- a/src/store/general/mutations.ts
+++ b/src/store/general/mutations.ts
@@ -9,6 +9,7 @@ import {
   ConnectionType,
   GeneralStateInterface as State,
   SubstrateAccount,
+  UnifiedAccount,
 } from './state';
 
 export interface GeneralMutations<S = State> {
@@ -30,6 +31,7 @@ export interface GeneralMutations<S = State> {
   setCurrentWallet(state: S, wallet: string): void;
   setGas(state: S, gas: GasTip): void;
   setCurrentBlock(state: S, blockNumber: number): void;
+  setUnifiedAccount(state: S, unifiedAccount: UnifiedAccount): void;
 }
 
 const mutation: MutationTree<State> & GeneralMutations = {
@@ -109,6 +111,9 @@ const mutation: MutationTree<State> & GeneralMutations = {
   },
   setCurrentBlock(state, blockNumber) {
     state.currentBlock = blockNumber;
+  },
+  setUnifiedAccount(state, unifiedAccount) {
+    state.unifiedAccount = unifiedAccount;
   },
 };
 

--- a/src/store/general/state.ts
+++ b/src/store/general/state.ts
@@ -30,6 +30,11 @@ export type EcdsaAccount = {
   h160: string;
 };
 
+export type UnifiedAccount = {
+  SS58Address: string;
+  H160Address: string;
+};
+
 export type ConnectionType = 'connected' | 'connecting' | 'offline';
 
 export type Theme = 'LIGHT' | 'DARK';
@@ -56,6 +61,7 @@ export interface GeneralStateInterface {
   currentWallet: string;
   gas: GasTip | undefined;
   currentBlock: number;
+  unifiedAccount?: UnifiedAccount;
 }
 
 function state(): GeneralStateInterface {

--- a/src/v2/app.container.ts
+++ b/src/v2/app.container.ts
@@ -29,7 +29,7 @@ import {
   AssetsRepository,
   PolkasafeRepository,
   AccountsRepository,
-  BluezNftRepository,
+  NftRepository,
   AccountUnificationRepository,
 } from './repositories/implementations';
 import {
@@ -130,7 +130,7 @@ export default function buildDependencyContainer(network: endpointKey): void {
   container.addTransient<IAssetsRepository>(AssetsRepository, Symbols.AssetsRepository);
   container.addSingleton<IAccountsRepository>(AccountsRepository, Symbols.AccountsRepository);
   container.addSingleton<IIdentityRepository>(IdentityRepository, Symbols.IdentityRepository);
-  container.addSingleton<INftRepository>(BluezNftRepository, Symbols.BluezNftRepository);
+  container.addSingleton<INftRepository>(NftRepository, Symbols.NftRepository);
   container.addSingleton<IAccountUnificationRepository>(
     AccountUnificationRepository,
     Symbols.AccountUnificationRepository

--- a/src/v2/repositories/IIdentityRepository.ts
+++ b/src/v2/repositories/IIdentityRepository.ts
@@ -2,6 +2,6 @@ import { ExtrinsicPayload } from 'src/v2/integration';
 import { IdentityData } from 'src/v2/models';
 
 export interface IIdentityRepository {
-  getIdentity(address: string): Promise<IdentityData>;
+  getIdentity(address: string): Promise<IdentityData | undefined>;
   getSetIdentityCall(address: string, data: IdentityData): Promise<ExtrinsicPayload>;
 }

--- a/src/v2/repositories/INftRepository.ts
+++ b/src/v2/repositories/INftRepository.ts
@@ -1,6 +1,10 @@
 import { NftMetadata } from 'src/v2/models';
 
 export interface INftRepository {
-  getOwnedTokens(ownerAddress: string): Promise<NftMetadata[]>;
-  getNftMetadata(contractAddress: string, tokenId: string): Promise<NftMetadata | undefined>;
+  getOwnedTokens(network: string, ownerAddress: string): Promise<NftMetadata[]>;
+  getNftMetadata(
+    network: string,
+    contractAddress: string,
+    tokenId: string
+  ): Promise<NftMetadata | undefined>;
 }

--- a/src/v2/repositories/implementations/AccountsRepository.ts
+++ b/src/v2/repositories/implementations/AccountsRepository.ts
@@ -18,14 +18,14 @@ export class AccountsRepository implements IAccountsRepository {
 
     const api = await this.api.getApi();
 
-    return api.tx.accounts.claimEvmAccount(evmAddress, signature);
+    return api.tx.unifiedAccounts.claimEvmAccount(evmAddress, signature);
   }
 
   public async getMappedNativeAddress(evmAddress: string): Promise<string> {
     Guard.ThrowIfUndefined('evmAddress', evmAddress);
 
     const api = await this.api.getApi();
-    const nativeAddress = await api.query.accounts.nativeAccounts<AccountId32>(evmAddress);
+    const nativeAddress = await api.query.unifiedAccounts.nativeToEvm<AccountId32>(evmAddress);
 
     return nativeAddress.toString();
   }
@@ -34,7 +34,7 @@ export class AccountsRepository implements IAccountsRepository {
     Guard.ThrowIfUndefined('nativeAddress', nativeAddress);
 
     const api = await this.api.getApi();
-    const evmAddress = await api.query.accounts.evmAccounts<H160>(nativeAddress);
+    const evmAddress = await api.query.unifiedAccounts.evmToNative<H160>(nativeAddress);
 
     return evmAddress.toString();
   }

--- a/src/v2/repositories/implementations/NftRepository.ts
+++ b/src/v2/repositories/implementations/NftRepository.ts
@@ -3,13 +3,14 @@ import axios from 'axios';
 import { injectable } from 'inversify';
 import { NftMetadata } from 'src/v2/models';
 import { INftRepository } from 'src/v2/repositories';
+import { TOKEN_API_URL } from '@astar-network/astar-sdk-core';
 
 @injectable()
-export class BluezNftRepository implements INftRepository {
+export class NftRepository implements INftRepository {
   private readonly baseUrl = 'https://api.bluez.app/api/nft/v3/API_KEY';
 
-  public async getOwnedTokens(ownerAddress: string): Promise<NftMetadata[]> {
-    const ownedTokensUrl = `${this.baseUrl}/getNFTsForOwner?owner=${ownerAddress}&pageKey=1&pageSize=100`;
+  public async getOwnedTokens(network: string, ownerAddress: string): Promise<NftMetadata[]> {
+    const ownedTokensUrl = `${TOKEN_API_URL}/v1/${network}/nft/owned/${ownerAddress}?pageKey=1&pageSize=100`;
     const result = await axios.get(ownedTokensUrl);
     // memo we are not handling pagination atm. 100 tokens should be enough for now.
 
@@ -17,10 +18,11 @@ export class BluezNftRepository implements INftRepository {
   }
 
   public async getNftMetadata(
+    network: string,
     contractAddress: string,
     tokenId: string
   ): Promise<NftMetadata | undefined> {
-    const metadataUri = `${this.baseUrl}/getNFTMetadata?contractAddress=${contractAddress}&tokenId=${tokenId}`;
+    const metadataUri = `${TOKEN_API_URL}/v1/${network}/nft/metadata/${contractAddress}/${tokenId}`;
     const result = await axios.get(metadataUri);
 
     return result.data ?? undefined;

--- a/src/v2/repositories/implementations/index.ts
+++ b/src/v2/repositories/implementations/index.ts
@@ -19,5 +19,5 @@ export * from './xcm/BifrostXcmRepository';
 export * from './xcm/EquilibriumXcmRepository';
 export * from './xcm/UniqueXcmRepository';
 export * from './AccountsRepository';
-export * from './BluezNftRepository';
+export * from './NftRepository';
 export * from './AccountUnificationRepository';

--- a/src/v2/symbols.ts
+++ b/src/v2/symbols.ts
@@ -33,6 +33,6 @@ export const Symbols = {
   AccountsRepository: Symbol.for('AccountsRepository'),
   IdentityRepository: Symbol.for('IdentityRepository'),
   IdentityService: Symbol.for('IdentityService'),
-  BluezNftRepository: Symbol.for('BluezNftRepository'),
+  NftRepository: Symbol.for('NftRepository'),
   AccountUnificationRepository: Symbol.for('AccountUnificationRepository'),
 };


### PR DESCRIPTION
**Pull Request Summary**

- Updated asset transfer logic to send assets to valid EVM account pair (unified SS58 address if account is unified)
- Fix fo getIdentity method in IndetityRepository
- Updated NftRepository to use Token API endpoint

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices


