### PR TITLE
fix: fetch dApps staking data after changing accounts

### DIFF
--- a/src/components/dapp-staking/my-staking/components/NewsArea.vue
+++ b/src/components/dapp-staking/my-staking/components/NewsArea.vue
@@ -267,7 +267,7 @@ export default defineComponent({
   color: $navy-1;
 
   @media (min-width: $md) {
-    bottom: 35px;
+    bottom: 48px;
   }
 }
 .colum--current-page {

--- a/src/hooks/dapps-staking/useDispatchGetDapps.ts
+++ b/src/hooks/dapps-staking/useDispatchGetDapps.ts
@@ -30,12 +30,9 @@ export function useDispatchGetDapps() {
   };
 
   const getDapps = async (): Promise<void> => {
-    console.log('currentAccount', currentAccount.value);
     const isConnectedWallet = currentNetworkName.value && currentAccount.value;
-    // if (isConnectedWallet && dapps.value.length === 0) {
     if (isConnectedWallet) {
       const address = !currentAccount.value ? '' : currentAccount.value;
-      console.log('address', address);
       store.dispatch('dapps/getDapps', {
         network: currentNetworkName.value.toLowerCase(),
         currentAccount: address,

--- a/src/hooks/dapps-staking/useDispatchGetDapps.ts
+++ b/src/hooks/dapps-staking/useDispatchGetDapps.ts
@@ -1,13 +1,12 @@
 import { useAccount, useNetworkInfo } from 'src/hooks';
 import { wait } from '@astar-network/astar-sdk-core';
 import { useStore } from 'src/store';
-import { computed, watchEffect } from 'vue';
+import { computed, watch } from 'vue';
 
 export function useDispatchGetDapps() {
   const store = useStore();
   const { currentNetworkName } = useNetworkInfo();
   const { currentAccount } = useAccount();
-  const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
   const dapps = computed(() => store.getters['dapps/getAllDapps']);
 
   // Memo: invoke this function whenever the users haven't connect to wallets
@@ -31,9 +30,12 @@ export function useDispatchGetDapps() {
   };
 
   const getDapps = async (): Promise<void> => {
+    console.log('currentAccount', currentAccount.value);
     const isConnectedWallet = currentNetworkName.value && currentAccount.value;
-    if (isConnectedWallet && dapps.value.length === 0) {
+    // if (isConnectedWallet && dapps.value.length === 0) {
+    if (isConnectedWallet) {
       const address = !currentAccount.value ? '' : currentAccount.value;
+      console.log('address', address);
       store.dispatch('dapps/getDapps', {
         network: currentNetworkName.value.toLowerCase(),
         currentAccount: address,
@@ -43,7 +45,5 @@ export function useDispatchGetDapps() {
     }
   };
 
-  watchEffect(async () => {
-    await getDapps();
-  });
+  watch([currentAccount, currentNetworkName], getDapps);
 }

--- a/src/hooks/dapps-staking/useStake.ts
+++ b/src/hooks/dapps-staking/useStake.ts
@@ -15,10 +15,10 @@ import { useI18n } from 'vue-i18n';
 export function useStake() {
   const router = useRouter();
   const route = useRoute();
-  const { currentAccount } = useAccount();
+  const { currentAccount, senderSs58Account } = useAccount();
   const { stakingList } = useStakingList();
   const isStakePage = computed<boolean>(() => route.fullPath.includes('stake'));
-  const addressTransferFrom = ref<string>(currentAccount.value);
+  const addressTransferFrom = ref<string>(senderSs58Account.value);
   const { t } = useI18n();
   const store = useStore();
 
@@ -34,8 +34,8 @@ export function useStake() {
       const item = stakingListRef.find((it) => it.address === addressTransferFrom.value);
       if (!item) return defaultData;
 
-      const name = item.name === currentAccount.value ? 'Transferable Balance' : item.name;
-      const isNominationTransfer = item.address !== currentAccount.value;
+      const name = item.name === senderSs58Account.value ? 'Transferable Balance' : item.name;
+      const isNominationTransfer = item.address !== senderSs58Account.value;
       const formattedText = `${name} (${balanceFormatter(item.balance, ASTAR_DECIMALS)})`;
       return { text: formattedText, item, isNominationTransfer };
     } catch (error) {
@@ -97,9 +97,9 @@ export function useStake() {
   };
 
   watch(
-    [currentAccount],
+    [senderSs58Account],
     () => {
-      addressTransferFrom.value = currentAccount.value;
+      addressTransferFrom.value = senderSs58Account.value;
     },
     { immediate: true }
   );


### PR DESCRIPTION
**Pull Request Summary**

* fix: fetch dApps staking data after changing accounts
* fix: page column position

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**
* fix: fetch dApps staking data after changing accounts
  * User's staking data was not updated after changing accounts.

=Before=
`Yyaq...vBMF` has staked on 6 dApps but it can't be found on the 'select' modal (for nomination transfer) 

![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/bfe0facb-81d3-4589-a944-0b9a821738a9)

![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/01e31c5b-d9d5-4df8-aac9-643f2629fb5b)

![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/f89e9da5-ba78-45ce-8685-3b999b977d5c)

=After=
![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/eac12acc-615b-4c15-aea5-49d89d4b3d07)


* fix: page column position

=Before=
![telegram-cloud-photo-size-5-6118290461044095341-y](https://github.com/AstarNetwork/astar-apps/assets/92044428/96a1db26-b7b5-444d-97d0-cb1538a6afad)

=After=
![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/07e2c6d7-c099-401b-aafa-c4cbfb8d8e22)
