### PR TITLE
Fix for invalid total account balance value

### DIFF
--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -97,7 +97,7 @@ function useCall(addressRef: Ref<string>) {
       locks
     );
 
-    balanceRef.value = accountInfo.data.free;
+    balanceRef.value = accountInfo.data.free.add(accountInfo.data.reserved);
   };
 
   const updateAccountBalance = () => {


### PR DESCRIPTION
**Pull Request Summary**

We didn't calculated reserved tokens into total balance.

BEFORE
Poladot portal shows 16.67 SBY total balance, while the portal shows 15.67 SBY
![image](https://github.com/AstarNetwork/astar-apps/assets/8452361/de4eb942-ddbd-4fe9-802c-da2a85e6d420)
![image](https://github.com/AstarNetwork/astar-apps/assets/8452361/5e2d8dbb-36f8-48c7-8840-b7531d8254ee)

NOW
<img width="704" alt="image" src="https://github.com/AstarNetwork/astar-apps/assets/8452361/37846978-d5ef-44b4-b455-c2b3c5cb68f6">


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

