### PR TITLE
fix: disabled transaction speed UI for Shibuya EVM

### DIFF
--- a/src/components/assets/transfer/LocalTransfer.vue
+++ b/src/components/assets/transfer/LocalTransfer.vue
@@ -102,7 +102,7 @@
         </div>
       </div>
 
-      <div class="separator" />
+      <div v-if="isEnableSpeedConfiguration" class="separator" />
 
       <speed-configuration
         v-if="isEnableSpeedConfiguration"

--- a/src/config/web3/index.ts
+++ b/src/config/web3/index.ts
@@ -9,6 +9,7 @@ export {
   getTokenExplorer,
   fetchErc20TokenInfo,
   getTokenDetails,
+  checkIsSetGasByWallet,
 } from 'src/config/web3/utils';
 
 export { contractInstance, Staking } from 'src/config/web3/contracts';

--- a/src/config/web3/utils/index.ts
+++ b/src/config/web3/utils/index.ts
@@ -221,3 +221,12 @@ export const fetchErc20TokenInfo = async ({
     return null;
   }
 };
+
+export const checkIsSetGasByWallet = (chainId: EVM): boolean => {
+  switch (chainId) {
+    case EVM.SHIBUYA_TESTNET:
+      return true;
+    default:
+      return false;
+  }
+};

--- a/src/hooks/transfer/useTokenTransfer.ts
+++ b/src/hooks/transfer/useTokenTransfer.ts
@@ -58,8 +58,7 @@ export function useTokenTransfer(selectedToken: Ref<Asset>) {
   const route = useRoute();
   const router = useRouter();
 
-  const { nativeTokenSymbol, evmNetworkIdx, isSupportXvmTransfer, currentNetworkName } =
-    useNetworkInfo();
+  const { nativeTokenSymbol, evmNetworkIdx, isSupportXvmTransfer } = useNetworkInfo();
   const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
   const tokenSymbol = computed<string>(() => route.query.token as string);
   const isLoading = computed<boolean>(() => store.getters['general/isLoading']);
@@ -127,13 +126,13 @@ export function useTokenTransfer(selectedToken: Ref<Asset>) {
     if (isLoading.value) return;
     const transferAmtRef = Number(transferAmt.value);
     try {
-      if (transferAmtRef > fromAddressBalance.value) {
+      if (transferAmtRef && transferAmtRef > fromAddressBalance.value) {
         errMsg.value = t('warning.insufficientBalance', {
           token: selectedToken.value.metadata.symbol,
         });
       } else if (toAddress.value && !isValidDestAddress.value) {
         errMsg.value = 'warning.inputtedInvalidDestAddress';
-      } else if (!transferableBalance.value && !isH160.value) {
+      } else if (transferAmtRef && !transferableBalance.value && !isH160.value) {
         errMsg.value = t('warning.insufficientBalance', {
           token: nativeTokenSymbol.value,
         });
@@ -190,7 +189,6 @@ export function useTokenTransfer(selectedToken: Ref<Asset>) {
           decimals,
           finalizedCallback,
           successMessage,
-          network: currentNetworkName.value.toLowerCase(),
         });
       } else {
         const receivingAddress = isValidEvmAddress(toAddress)

--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -30,6 +30,8 @@ export const useGasPrice = (isFetch = false) => {
   const network = computed<string>(() => {
     return isMainnet ? currentNetworkName.value.toLowerCase() : 'shibuya';
   });
+  const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
+  const isShibuyaEvm = computed<boolean>(() => isH160.value && network.value === 'shibuya');
 
   const setSelectedGas = (speed: Speed): void => {
     selectedGas.value = {
@@ -86,14 +88,21 @@ export const useGasPrice = (isFetch = false) => {
     return (
       currentWallet !== SupportWallet.TalismanEvm &&
       currentWallet !== SupportWallet.SubWalletEvm &&
-      currentWallet !== SupportWallet.OneKeyEvm
+      currentWallet !== SupportWallet.OneKeyEvm &&
+      !isShibuyaEvm.value
     );
   });
 
   watch(
     [network, $web3],
     async () => {
-      if (isFetch && network.value && !gas.value && $web3.value) {
+      if (
+        isFetch &&
+        network.value &&
+        !gas.value &&
+        $web3.value &&
+        isEnableSpeedConfiguration.value
+      ) {
         // console.info('gas price', network.value, gas.value);
         await dispatchGasPrice(network.value);
       }

--- a/src/v2/services/IAssetsService.ts
+++ b/src/v2/services/IAssetsService.ts
@@ -21,7 +21,6 @@ export interface ParamEvmTransfer {
   contractAddress: string;
   decimals: number;
   successMessage: string;
-  network: string;
   finalizedCallback: (hash: string) => void;
 }
 


### PR DESCRIPTION
**Pull Request Summary**

* fix: disabled transaction speed UI for Shibuya EVM as users can select the speed on their wallet
  * we can remove it for Astar and Shinde once rutime apply the dynamic gas price for EVM

* fix: stop fetching gas price if users connect to Shibuya EVM
* fix: removed duplicated fetch gas price logic
* fix: refactored fetching gas price logic by checking the provider's connecting chain ID 
* fix: avoid displaying `insufficient ${token} balance` message at the very first moment when the app render the transfer page 

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**
* fix: disabled transaction speed UI for Shibuya EVM 
=Before=
![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/be1f8a58-364f-4f75-80fd-f895f350b341)

=After=
![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/f27e0514-e110-4478-9734-d6cd5dab5c02)

* fix: avoid displaying insufficient ${token} balance message at the very first moment when the app displays transfer page

=Before=
![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/85d01c42-7cd2-47ac-8dd4-ce5526a63141)

Gif: https://gyazo.com/4c541527a593baf1e909f5509e6a0822