### PR TITLE
fix: Account Unification errors

### DIFF
--- a/src/components/assets/Account.vue
+++ b/src/components/assets/Account.vue
@@ -94,6 +94,7 @@ import { $api } from 'src/boot/api';
 import EvmNativeToken from 'src/components/assets/EvmNativeToken.vue';
 import NativeAssetList from 'src/components/assets/NativeAssetList.vue';
 import ZkAstr from 'src/components/assets/ZkAstr.vue';
+import AuIcon from 'src/components/header/modals/account-unification/AuIcon.vue';
 import { endpointKey, providerEndpoints } from 'src/config/chainEndpoints';
 import { supportWalletObj } from 'src/config/wallets';
 import {
@@ -116,6 +117,7 @@ export default defineComponent({
     NativeAssetList,
     EvmNativeToken,
     ZkAstr,
+    AuIcon,
   },
   props: {
     ttlErc20Amount: {

--- a/src/components/assets/XcmCurrency.vue
+++ b/src/components/assets/XcmCurrency.vue
@@ -97,7 +97,12 @@ export default defineComponent({
     const explorerLink = computed<string>(() => {
       const astarBalanceUrl = 'https://astar.subscan.io/assets/' + t.value.id;
       const shidenBalanceUrl = 'https://shiden.subscan.io/assets/' + t.value.id;
-      return currentNetworkIdx.value === endpointKey.ASTAR ? astarBalanceUrl : shidenBalanceUrl;
+      const shibuyaBalanceUrl = 'https://shibuya.subscan.io/assets/' + t.value.id;
+      return currentNetworkIdx.value === endpointKey.ASTAR
+        ? astarBalanceUrl
+        : currentNetworkIdx.value === endpointKey.SHIDEN
+        ? shidenBalanceUrl
+        : shibuyaBalanceUrl;
     });
 
     return {

--- a/src/components/header/modals/account-unification/AuIcon.vue
+++ b/src/components/header/modals/account-unification/AuIcon.vue
@@ -4,8 +4,7 @@
 </template>
 
 <script lang="ts">
-import { UnifiedAccount } from 'src/store/general/state';
-import { defineComponent, PropType } from 'vue';
+import { defineComponent } from 'vue';
 import Jazzicon from 'vue3-jazzicon/src/components';
 
 export default defineComponent({

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -129,21 +129,6 @@ export const useAccount = () => {
     }
   };
 
-  // TODO Move to separate lib, probably update toSS58Address in astar.js
-  const getSS58Address = async (evmAddress: string): Promise<string> => {
-    if (isValidEvmAddress(evmAddress)) {
-      const service = container.get<IAccountUnificationService>(Symbols.AccountUnificationService);
-      const ss58Pair = await service.getMappedNativeAddress(evmAddress);
-      if (ss58Pair) {
-        return ss58Pair;
-      } else {
-        return toSS58Address(evmAddress);
-      }
-    }
-
-    return evmAddress;
-  };
-
   const showAccountUnificationModal = (): void => {
     const eventAggregator = container.get<IEventAggregator>(Symbols.EventAggregator);
     eventAggregator.publish(new UnifyAccountMessage());
@@ -249,7 +234,6 @@ export const useAccount = () => {
     isAccountUnification,
     isH160Formatted,
     disconnectAccount,
-    getSS58Address,
     showAccountUnificationModal,
     checkIfUnified,
   };

--- a/src/hooks/xcm/useXcmBridge.ts
+++ b/src/hooks/xcm/useXcmBridge.ts
@@ -5,7 +5,6 @@ import {
   capitalize,
   isValidAddressPolkadotAddress,
   isValidEvmAddress,
-  toSS58Address,
 } from '@astar-network/astar-sdk-core';
 import { ApiPromise } from '@polkadot/api';
 import { ethers } from 'ethers';
@@ -40,7 +39,12 @@ import { Path } from 'src/router';
 import { container } from 'src/v2/common';
 import { AstarToken } from 'src/v2/config/xcm/XcmRepositoryConfiguration';
 import { IApiFactory } from 'src/v2/integration';
-import { IXcmEvmService, IXcmService, IXcmTransfer } from 'src/v2/services';
+import {
+  IAccountUnificationService,
+  IXcmEvmService,
+  IXcmService,
+  IXcmTransfer,
+} from 'src/v2/services';
 import { Symbols } from 'src/v2/symbols';
 import { useRouter } from 'vue-router';
 import { castChainName, castXcmEndpoint } from 'src/modules/xcm';
@@ -337,10 +341,15 @@ export function useXcmBridge(selectedToken: Ref<Asset>) {
     ) {
       return 0;
     }
+    const accountUnificationService = container.get<IAccountUnificationService>(
+      Symbols.AccountUnificationService
+    );
     if (isDeposit.value) {
       // if: SS58 Deposit
       const isSendToH160 = isValidEvmAddress(address);
-      const destAddress = isSendToH160 ? toSS58Address(address) : address;
+      const destAddress = isSendToH160
+        ? await accountUnificationService.getMappedNativeAddress(address)
+        : address;
       if (isAstarNativeTransfer.value) {
         const accountInfo = await $api?.query.system.account<SystemAccount>(address);
         const bal = accountInfo!.data.free || '0';

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -55,6 +55,7 @@ export default {
     insufficientBalance: 'Insufficient {token} balance',
     insufficientFee: 'Warning! Transaction might fail due to insufficient fee',
     inputtedInvalidDestAddress: 'Inputted invalid destination address',
+    inputtedNotUnifiedDestAddress: 'Inputted destination address has not been unified',
     blankDestAddress: 'Destination address is blank',
     inputtedInvalidAddress: 'Inputted invalid address',
     selectedInvalidNetworkInWallet: 'Selected invalid network in your wallet',

--- a/src/store/dapp-staking/actions.ts
+++ b/src/store/dapp-staking/actions.ts
@@ -15,7 +15,7 @@ import { StateInterface } from '../index';
 import { sign } from './../../hooks/helper/wallet';
 import { SubstrateAccount } from './../general/state';
 import { DappStateInterface as State, NewDappItem, FileInfo } from './state';
-import { IDappStakingService } from 'src/v2/services';
+import { IAccountUnificationService, IDappStakingService } from 'src/v2/services';
 import { container } from 'src/v2/common';
 import { Symbols } from 'src/v2/symbols';
 import axios, { AxiosError } from 'axios';
@@ -25,7 +25,6 @@ import {
   TOKEN_API_URL,
   DappItem,
   isValidEvmAddress,
-  toSS58Address,
 } from '@astar-network/astar-sdk-core';
 
 const showError = (dispatch: Dispatch, message: string): void => {
@@ -91,14 +90,16 @@ const actions: ActionTree<State, StateInterface> = {
     { commit, dispatch },
     { network, currentAccount }: { network: string; currentAccount: string }
   ) {
-    // commit('general/setLoading', true, { root: true });
+    const accountUnificationService = container.get<IAccountUnificationService>(
+      Symbols.AccountUnificationService
+    );
 
     try {
       // Fetch dapps
       const dappsUrl = `${TOKEN_API_URL}/v1/${network.toLowerCase()}/dapps-staking/dappssimple`;
       const service = container.get<IDappStakingService>(Symbols.DappStakingService);
       const address = isValidEvmAddress(currentAccount)
-        ? toSS58Address(currentAccount)
+        ? await accountUnificationService.getMappedNativeAddress(currentAccount)
         : currentAccount;
       const [dapps, combinedInfo] = await Promise.all([
         axios.get<DappItem[]>(dappsUrl),

--- a/src/v2/repositories/IAccountUnificationRepository.ts
+++ b/src/v2/repositories/IAccountUnificationRepository.ts
@@ -26,6 +26,12 @@ export interface IAccountUnificationRepository {
   getMappedEvmAddress(nativeAddress: string): Promise<string>;
 
   /**
+   * check if the given address is unified account.
+   * @param address H160 or SS58 address.
+   */
+  handleCheckIsUnifiedAccount(address: string): Promise<boolean>;
+
+  /**
    * Gets batch all call to unify accounts and to set the account identity.
    * @param nativeAddress Native address to unify.
    * @param evmAddress EVM address to unify.

--- a/src/v2/repositories/implementations/AccountUnificationRepository.ts
+++ b/src/v2/repositories/implementations/AccountUnificationRepository.ts
@@ -1,3 +1,4 @@
+import { buildEvmAddress, toSS58Address } from '@astar-network/astar-sdk-core';
 import { AccountId32, H160 } from '@polkadot/types/interfaces';
 import { inject, injectable } from 'inversify';
 import { Guard } from 'src/v2/common';
@@ -29,24 +30,22 @@ export class AccountUnificationRepository implements IAccountUnificationReposito
     Guard.ThrowIfUndefined('evmAddress', evmAddress);
 
     const api = await this.api.getApi();
-    // Todo: update the function name once Shibuya runtime has been updated.
     const nativeAddress = api.query.hasOwnProperty('unifiedAccounts')
       ? await api.query.unifiedAccounts.evmToNative<AccountId32>(evmAddress)
-      : '';
+      : toSS58Address(evmAddress);
 
-    return nativeAddress.toString();
+    return nativeAddress.toString() !== '' ? nativeAddress.toString() : toSS58Address(evmAddress);
   }
 
   public async getMappedEvmAddress(nativeAddress: string): Promise<string> {
     Guard.ThrowIfUndefined('nativeAddress', nativeAddress);
 
     const api = await this.api.getApi();
-    // Todo: update the function name once Shibuya runtime has been updated.
     const evmAddress = api.query.hasOwnProperty('unifiedAccounts')
       ? await api.query.unifiedAccounts.nativeToEvm<H160>(nativeAddress)
-      : '';
+      : buildEvmAddress(nativeAddress);
 
-    return evmAddress.toString();
+    return evmAddress.toString() !== '' ? evmAddress.toString() : buildEvmAddress(nativeAddress);
   }
 
   public async getUnifyAccountsBatchAllCall(

--- a/src/v2/repositories/implementations/AccountUnificationRepository.ts
+++ b/src/v2/repositories/implementations/AccountUnificationRepository.ts
@@ -1,4 +1,4 @@
-import { buildEvmAddress, toSS58Address } from '@astar-network/astar-sdk-core';
+import { buildEvmAddress, isValidEvmAddress, toSS58Address } from '@astar-network/astar-sdk-core';
 import { AccountId32, H160 } from '@polkadot/types/interfaces';
 import { inject, injectable } from 'inversify';
 import { Guard } from 'src/v2/common';
@@ -46,6 +46,21 @@ export class AccountUnificationRepository implements IAccountUnificationReposito
       : buildEvmAddress(nativeAddress);
 
     return evmAddress.toString() !== '' ? evmAddress.toString() : buildEvmAddress(nativeAddress);
+  }
+
+  public async handleCheckIsUnifiedAccount(address: string): Promise<boolean> {
+    Guard.ThrowIfUndefined('address', address);
+
+    const api = await this.api.getApi();
+    const isEvmAddress = isValidEvmAddress(address);
+    const isRuntimeApplied = api.query.hasOwnProperty('unifiedAccounts');
+    if (!isRuntimeApplied) return false;
+
+    const mappedAddress = isEvmAddress
+      ? await api.query.unifiedAccounts.evmToNative<AccountId32>(address)
+      : await api.query.unifiedAccounts.nativeToEvm<H160>(address);
+
+    return mappedAddress.toString() !== '';
   }
 
   public async getUnifyAccountsBatchAllCall(

--- a/src/v2/repositories/implementations/AssetsRepository.ts
+++ b/src/v2/repositories/implementations/AssetsRepository.ts
@@ -61,6 +61,7 @@ export class AssetsRepository implements IAssetsRepository {
       };
     }
   }
+
   public async getEvmWithdrawCall({
     amount,
     senderAddress,
@@ -69,10 +70,12 @@ export class AssetsRepository implements IAssetsRepository {
     const h160Addr = buildEvmAddress(senderAddress);
     return api.tx.evm.withdraw(h160Addr, amount);
   }
+
   public async getVestCall(): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>> {
     const api = await this.api.getApi();
     return api.tx.vesting.vest();
   }
+
   public async getNativeBalance(address: string): Promise<string> {
     try {
       const api = await this.api.getApi();

--- a/src/v2/services/IAccountUnificationService.ts
+++ b/src/v2/services/IAccountUnificationService.ts
@@ -8,4 +8,5 @@ export interface IAccountUnificationService {
   ): Promise<boolean>;
   getMappedNativeAddress(evmAddress: string): Promise<string>;
   getMappedEvmAddress(nativeAddress: string): Promise<string>;
+  checkIsUnifiedAccount(address: string): Promise<boolean>;
 }

--- a/src/v2/services/implementations/AccountUnificationService.ts
+++ b/src/v2/services/implementations/AccountUnificationService.ts
@@ -99,4 +99,9 @@ export class AccountUnificationService implements IAccountUnificationService {
 
     return await this.unificationRepo.getMappedEvmAddress(nativeAddress);
   }
+  public async checkIsUnifiedAccount(address: string): Promise<boolean> {
+    Guard.ThrowIfUndefined('address', address);
+
+    return await this.unificationRepo.handleCheckIsUnifiedAccount(address);
+  }
 }


### PR DESCRIPTION
**Pull Request Summary**

* fix: displaying account icon
* fix: use unified account
  * map to proper SS58 address for EVM dApp staking
  * map to proper H160 address for sending assets from EVM to Native(unified)

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**
* fix: displaying account icon

=Before=
* Not unified account but `isUnifiedAccount` was true
![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/de66588f-93e5-47cb-a5fe-2f4f1ad5939c)

* This is unified account but `AuIcon` component was not imported
![Screenshot 2023-11-01 at 3 10 05 PM](https://github.com/AstarNetwork/astar-apps/assets/92044428/cb4edf7f-f167-4c7a-b66f-da861327191b)

=After=
![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/16417a7d-4b17-42ca-89d4-b356f76ba599)


**Changes**

* removed `getSS58Address` function from `useAccount` hooks and use `getMappedNativeAddress` from `AccountUnificationService`
