### PR TITLE
fix: modify the way query the mapped address

### DIFF
--- a/src/components/header/modals/ModalAccount.vue
+++ b/src/components/header/modals/ModalAccount.vue
@@ -226,6 +226,7 @@ export default defineComponent({
         const wallet = substrateAccounts.value.find((it) => it.address === substrateAccount);
         wallet && localStorage.setItem(LOCAL_STORAGE.SELECTED_WALLET, wallet.source);
       }
+      store.commit('general/setCurrentWallet', props.selectedWallet);
       isSelected.value = true;
       isClosing.value = false;
       localStorage.removeItem(LOCAL_STORAGE.MULTISIG);

--- a/src/hooks/transfer/useTokenTransfer.ts
+++ b/src/hooks/transfer/useTokenTransfer.ts
@@ -194,7 +194,7 @@ export function useTokenTransfer(selectedToken: Ref<Asset>) {
       if (isH160.value) {
         const receivingAddress = isValidEvmAddress(toAddress)
           ? toAddress
-          : await accountUnificationService.getMappedEvmAddress(toAddress);
+          : await accountUnificationService.getConvertedEvmAddress(toAddress);
         const successMessage = t('assets.toast.completedMessage', {
           symbol,
           transferAmt,
@@ -211,7 +211,7 @@ export function useTokenTransfer(selectedToken: Ref<Asset>) {
         });
       } else {
         const receivingAddress = isValidEvmAddress(toAddress)
-          ? await accountUnificationService.getMappedNativeAddress(toAddress)
+          ? await accountUnificationService.getConvertedNativeAddress(toAddress)
           : toAddress;
         const successMessage = t('assets.toast.completedMessage', {
           symbol,
@@ -264,7 +264,7 @@ export function useTokenTransfer(selectedToken: Ref<Asset>) {
 
     const isSendToH160 = isValidEvmAddress(toAddress.value);
     const destAddress = isSendToH160
-      ? await accountUnificationService.getMappedNativeAddress(toAddress.value)
+      ? await accountUnificationService.getConvertedNativeAddress(toAddress.value)
       : toAddress.value;
     const srcChainId = evmNetworkIdx.value;
 
@@ -272,7 +272,7 @@ export function useTokenTransfer(selectedToken: Ref<Asset>) {
       toAddressBalance.value = await getNativeTokenBalance(destAddress);
     } else if (isH160.value) {
       const address = isValidAddressPolkadotAddress(toAddress.value)
-        ? await accountUnificationService.getMappedEvmAddress(toAddress.value)
+        ? await accountUnificationService.getConvertedEvmAddress(toAddress.value)
         : toAddress.value;
 
       const balance = await getTokenBal({

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -84,8 +84,8 @@ export const useAccount = () => {
 
     const isEvmAddress = isValidEvmAddress(address);
     const mapped = isEvmAddress
-      ? await service.getMappedNativeAddress(address)
-      : await service.getMappedEvmAddress(address);
+      ? await service.getConvertedNativeAddress(address)
+      : await service.getConvertedEvmAddress(address);
 
     if (mapped) {
       const identityRepository = container.get<IdentityRepository>(Symbols.IdentityRepository);

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -84,8 +84,8 @@ export const useAccount = () => {
 
     const isEvmAddress = isValidEvmAddress(address);
     const mapped = isEvmAddress
-      ? await service.getConvertedNativeAddress(address)
-      : await service.getConvertedEvmAddress(address);
+      ? await service.getMappedNativeAddress(address)
+      : await service.getMappedEvmAddress(address);
 
     if (mapped) {
       const identityRepository = container.get<IdentityRepository>(Symbols.IdentityRepository);

--- a/src/hooks/wallet/useAccountUnification.ts
+++ b/src/hooks/wallet/useAccountUnification.ts
@@ -127,7 +127,7 @@ export const useAccountUnification = () => {
       let isPendingWithdrawal = false;
       let stakingData: MyStakeInfo[] = [];
 
-      const mappedSS58Address = await accountUnificationService.getMappedNativeAddress(
+      const mappedSS58Address = await accountUnificationService.getConvertedNativeAddress(
         selectedEvmAddress.value
       );
       const dappStakingService = container.get<IDappStakingService>(Symbols.DappStakingService);

--- a/src/hooks/xcm/useXcmBridge.ts
+++ b/src/hooks/xcm/useXcmBridge.ts
@@ -349,7 +349,7 @@ export function useXcmBridge(selectedToken: Ref<Asset>) {
       // if: SS58 Deposit
       const isSendToH160 = isValidEvmAddress(address);
       const destAddress = isSendToH160
-        ? await accountUnificationService.getMappedNativeAddress(address)
+        ? await accountUnificationService.getConvertedNativeAddress(address)
         : address;
       if (isAstarNativeTransfer.value) {
         const accountInfo = await $api?.query.system.account<SystemAccount>(address);

--- a/src/v2/repositories/IAccountUnificationRepository.ts
+++ b/src/v2/repositories/IAccountUnificationRepository.ts
@@ -14,16 +14,28 @@ export interface IAccountUnificationRepository {
   getClaimEvmAccountCall(evmAddress: string, signature: string): Promise<ExtrinsicPayload>;
 
   /**
-   * Gets mapped native address for the given EVM address.
+   * Queries mapped native address for the given EVM address in runtime.
    * @param evmAddress EVM address to get mapped native address.
    */
   getMappedNativeAddress(evmAddress: string): Promise<string>;
 
   /**
-   * Gets mapped EVM address for the given native address.
+   * Queries mapped EVM address for the given native address in runtime.
    * @param nativeAddress Native address to get mapped EVM address.
    */
   getMappedEvmAddress(nativeAddress: string): Promise<string>;
+
+  /**
+   * Gets mapped native address for the given EVM address.
+   * @param evmAddress EVM address to get mapped native address.
+   */
+  getConvertedNativeAddress(evmAddress: string): Promise<string>;
+
+  /**
+   * Gets mapped EVM address for the given native address.
+   * @param nativeAddress Native address to get mapped EVM address.
+   */
+  getConvertedEvmAddress(nativeAddress: string): Promise<string>;
 
   /**
    * check if the given address is unified account.

--- a/src/v2/repositories/implementations/AccountUnificationRepository.ts
+++ b/src/v2/repositories/implementations/AccountUnificationRepository.ts
@@ -33,9 +33,9 @@ export class AccountUnificationRepository implements IAccountUnificationReposito
     const api = await this.api.getApi();
     const nativeAddress = api.query.hasOwnProperty('unifiedAccounts')
       ? await api.query.unifiedAccounts.evmToNative<AccountId32>(evmAddress)
-      : toSS58Address(evmAddress);
+      : '';
 
-    return nativeAddress.toString() !== '' ? nativeAddress.toString() : toSS58Address(evmAddress);
+    return nativeAddress.toString();
   }
 
   public async getMappedEvmAddress(nativeAddress: string): Promise<string> {
@@ -44,9 +44,21 @@ export class AccountUnificationRepository implements IAccountUnificationReposito
     const api = await this.api.getApi();
     const evmAddress = api.query.hasOwnProperty('unifiedAccounts')
       ? await api.query.unifiedAccounts.nativeToEvm<H160>(nativeAddress)
-      : buildEvmAddress(nativeAddress);
+      : '';
 
-    return evmAddress.toString() !== '' ? evmAddress.toString() : buildEvmAddress(nativeAddress);
+    return evmAddress.toString();
+  }
+
+  public async getConvertedNativeAddress(evmAddress: string): Promise<string> {
+    Guard.ThrowIfUndefined('evmAddress', evmAddress);
+    const nativeAddress = await this.getMappedNativeAddress(evmAddress);
+    return nativeAddress !== '' ? nativeAddress : toSS58Address(evmAddress);
+  }
+
+  public async getConvertedEvmAddress(nativeAddress: string): Promise<string> {
+    Guard.ThrowIfUndefined('nativeAddress', nativeAddress);
+    const evmAddress = await this.getMappedEvmAddress(nativeAddress);
+    return evmAddress !== '' ? evmAddress : buildEvmAddress(nativeAddress);
   }
 
   public async handleCheckIsUnifiedAccount(address: string): Promise<boolean> {

--- a/src/v2/services/IAccountUnificationService.ts
+++ b/src/v2/services/IAccountUnificationService.ts
@@ -8,5 +8,7 @@ export interface IAccountUnificationService {
   ): Promise<boolean>;
   getMappedNativeAddress(evmAddress: string): Promise<string>;
   getMappedEvmAddress(nativeAddress: string): Promise<string>;
+  getConvertedNativeAddress(evmAddress: string): Promise<string>;
+  getConvertedEvmAddress(nativeAddress: string): Promise<string>;
   checkIsUnifiedAccount(address: string): Promise<boolean>;
 }

--- a/src/v2/services/implementations/AccountUnificationService.ts
+++ b/src/v2/services/implementations/AccountUnificationService.ts
@@ -99,6 +99,22 @@ export class AccountUnificationService implements IAccountUnificationService {
 
     return await this.unificationRepo.getMappedEvmAddress(nativeAddress);
   }
+
+  // Memo: return mapped native address for evm address
+  // 1. query in API
+  // 2. convert the address by SDK in case the account hasn't been unified
+  public async getConvertedNativeAddress(evmAddress: string): Promise<string> {
+    Guard.ThrowIfUndefined('evmAddress', evmAddress);
+
+    return await this.unificationRepo.getConvertedNativeAddress(evmAddress);
+  }
+
+  // Memo: return mapped EVM address for native address
+  public async getConvertedEvmAddress(nativeAddress: string): Promise<string> {
+    Guard.ThrowIfUndefined('nativeAddress', nativeAddress);
+
+    return await this.unificationRepo.getConvertedEvmAddress(nativeAddress);
+  }
   public async checkIsUnifiedAccount(address: string): Promise<boolean> {
     Guard.ThrowIfUndefined('address', address);
 


### PR DESCRIPTION
**Pull Request Summary**

* fix: modify the way query the mapped address
  * reverted both `getMappedEvmAddress` and `getMappedNativeAddress` function
  * use `getConvertedNativeAddress` and  `getConvertedEvmAddress` for fetch & calculate the maped address
* fix: modified ModalAcount.vue to update 'currentWallet' state correctly after selecting account   

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**
