### PR TITLE
Fix: EVM address casing

### DIFF
--- a/src/components/header/modals/UnifiedAccount.vue
+++ b/src/components/header/modals/UnifiedAccount.vue
@@ -32,7 +32,7 @@
       <div class="container--address container--address--eth">
         <img :src="walletIcons.evm" alt="Wallet icon" />
         <account
-          :account-address="evmAddress"
+          :account-address="checkSumEvmAddress(evmAddress)"
           :explorer-url="blockScout"
           :native-token-symbol="nativeTokenSymbol"
           :show-balance-value="false"
@@ -45,7 +45,7 @@
 </template>
 <script lang="ts">
 import { defineComponent, computed, PropType } from 'vue';
-import { getShortenAddress } from '@astar-network/astar-sdk-core';
+import { getShortenAddress, checkSumEvmAddress } from '@astar-network/astar-sdk-core';
 import Account from './Account.vue';
 import { providerEndpoints } from 'src/config/chainEndpoints';
 import { useNetworkInfo } from 'src/hooks';
@@ -101,7 +101,7 @@ export default defineComponent({
       () => `${providerEndpoints[currentNetworkIdx.value].blockscout}/address/`
     );
 
-    return { getShortenAddress, blockScout, walletIcons };
+    return { getShortenAddress, checkSumEvmAddress, blockScout, walletIcons };
   },
 });
 </script>

--- a/src/hooks/wallet/useAccountUnification.ts
+++ b/src/hooks/wallet/useAccountUnification.ts
@@ -5,6 +5,7 @@ import {
   getEvmGas,
   getIndividualClaimTxs,
   wait,
+  checkSumEvmAddress,
 } from '@astar-network/astar-sdk-core';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { ISubmittableResult } from '@polkadot/types/types';
@@ -84,7 +85,7 @@ export const useAccountUnification = () => {
     if (!provider || typeof window.ethereum === 'undefined') return;
     const [address] = (await provider.request({ method: 'eth_requestAccounts' })) as string;
     web3.value = new Web3(provider as any);
-    selectedEvmAddress.value = address;
+    selectedEvmAddress.value = checkSumEvmAddress(address);
     const chainId = `0x${evmNetworkIdx.value.toString(16)}`;
     if (provider.chainId !== chainId) {
       await setupNetwork({ network: evmNetworkIdx.value, provider });


### PR DESCRIPTION
**Pull Request Summary**

There is an EVM address formatting issue in account unification. Unified account EVM addresses were always displayed as lowercase

<img width="486" alt="image" src="https://github.com/AstarNetwork/astar-apps/assets/8452361/8505fbe0-75ab-45c3-b79e-34cdad3074a8">

<img width="454" alt="image" src="https://github.com/AstarNetwork/astar-apps/assets/8452361/c50ec41c-2c04-4c5f-a995-a0738df2b28c">


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
