### PR TITLE
fix: include vesting amount in locked tokens

### DIFF
--- a/src/components/assets/NativeAssetList.vue
+++ b/src/components/assets/NativeAssetList.vue
@@ -133,7 +133,7 @@
             </div>
             <div v-if="!isSkeleton" class="column--balance">
               <div class="column--amount text--amount">
-                {{ isTruncate ? $n(truncate(lockInDappStaking, 3)) : Number(lockInDappStaking) }}
+                {{ $n(truncate(lockInDappStaking + vestingTtl, 3)) }}
               </div>
               <div class="column--symbol text--symbol">
                 {{ nativeTokenSymbol }}


### PR DESCRIPTION
**Pull Request Summary**

* fix: include vesting amount in locked tokens

![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/b6d74246-3cca-4dd9-93f2-765bdb2ff1c8)


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

