### PR TITLE
fix: display background when the app is claiming rewards

### DIFF
--- a/src/components/assets/Assets.vue
+++ b/src/components/assets/Assets.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!isLoading" class="wrapper--assets">
+  <div v-if="xcmAssets.assets.length > 0 || !isLoading" class="wrapper--assets">
     <div class="assets-page-bg" :style="{ backgroundImage: `url(${bg})` }" />
     <div class="container--assets">
       <div class="column--main">
@@ -31,7 +31,6 @@
 </template>
 <script lang="ts">
 import Account from 'src/components/assets/Account.vue';
-import DynamicLinks from 'src/components/assets/DynamicLinks.vue';
 import SideAds from 'src/components/assets/SideAds.vue';
 import AstarDomains from 'src/components/header/mobile/AstarDomains.vue';
 import EvmAssetList from 'src/components/assets/EvmAssetList.vue';


### PR DESCRIPTION
**Pull Request Summary**

fix: display background when the app is claiming rewards

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**
=Before=
The loading background was black

=After=
![Screenshot 2023-11-23 at 4 54 06 PM](https://github.com/AstarNetwork/astar-apps/assets/92044428/9f37e4fe-c1cd-49c2-afa4-aecd35b5e192)
