### PR TITLE
fix: display the amount of estimated rewards for Shibuya

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "playwright:ci": "node ./tests/chopsticks/start-chopsticks.js"
   },
   "dependencies": {
-    "@astar-network/astar-sdk-core": "^0.2.5",
+    "@astar-network/astar-sdk-core": "^0.2.7",
     "@astar-network/astar-ui": "^0.0.136",
     "@astar-network/metamask-astar-adapter": "^0.5.4",
     "@astar-network/metamask-astar-types": "^0.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,10 +29,10 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
 
-"@astar-network/astar-sdk-core@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@astar-network/astar-sdk-core/-/astar-sdk-core-0.2.5.tgz#fdaa80f9b0b28516723785135f43b1c5ad9166f5"
-  integrity sha512-BVr9RUYPmaSyHaoNBhrqMWygD15lG78/AnDdaW6S1UGL8hJ/jI1a7dxjanwXKJV4v623Ic0NPJxDWY0oE7Ejsw==
+"@astar-network/astar-sdk-core@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@astar-network/astar-sdk-core/-/astar-sdk-core-0.2.7.tgz#378bd50fb32745a240dcfb1e518ddc27ee81f817"
+  integrity sha512-/kqdHVm4UZnGtfBv7RSaBRKOttyFDIzago8GWrjT01govGbohKx1npVOWl52w7MV9E494Q6vz2mJ7AoXnqJB5w==
   dependencies:
     "@ethersproject/bignumber" "^5.6.2"
     "@polkadot/util" "^12.3.2"


### PR DESCRIPTION
**Pull Request Summary**

* fix: display the amount of estimated rewards for Shibuya

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**
* fix: display the amount of estimated rewards for Shibuya

=Before=
It was 0

=After=
<img width="343" alt="image" src="https://github.com/AstarNetwork/astar-apps/assets/92044428/72e8cb06-56d5-4c2d-a4a6-e7f05ab793dd">
