### PR TITLE
EVM gas estimation fix

### DIFF
--- a/src/hooks/wallet/useAccountUnification.ts
+++ b/src/hooks/wallet/useAccountUnification.ts
@@ -280,14 +280,10 @@ export const useAccountUnification = () => {
     try {
       isSendingXc20Tokens.value = true;
       const from = selectedEvmAddress.value;
-      const [nonce, gasPrice] = await Promise.all([
-        web3.value.eth.getTransactionCount(from),
-        web3.value.eth.getGasPrice(),
-      ]);
-      const multipliedGas = Math.round(Number(gasPrice) * 1.01);
+      const nonce = await web3.value.eth.getTransactionCount(from);
+
       const rawTx = {
         nonce,
-        gasPrice: web3.value.utils.toHex(multipliedGas.toString()),
         from,
         to: evmPrecompiledContract.dispatch,
         value: '0x0',

--- a/src/hooks/wallet/useAccountUnification.ts
+++ b/src/hooks/wallet/useAccountUnification.ts
@@ -33,6 +33,7 @@ import { AbiItem } from 'web3-utils';
 import { useNetworkInfo } from '../useNetworkInfo';
 import { IAccountUnificationRepository, IIdentityRepository } from 'src/v2/repositories';
 import { UnifiedAccount } from 'src/store/general/state';
+import { getRawEvmTransaction } from 'src/modules/evm';
 
 const provider = get(window, 'ethereum') as any;
 
@@ -280,15 +281,14 @@ export const useAccountUnification = () => {
     try {
       isSendingXc20Tokens.value = true;
       const from = selectedEvmAddress.value;
-      const nonce = await web3.value.eth.getTransactionCount(from);
-
-      const rawTx = {
-        nonce,
+      const rawTx = await getRawEvmTransaction(
+        web3.value,
         from,
-        to: evmPrecompiledContract.dispatch,
-        value: '0x0',
-        data: transferXc20CallData.value,
-      };
+        evmPrecompiledContract.dispatch,
+        transferXc20CallData.value,
+        '0x0'
+      );
+
       const estimatedGas = await web3.value.eth.estimateGas(rawTx);
       await web3.value.eth
         .sendTransaction({ ...rawTx, gas: estimatedGas })

--- a/src/modules/evm/index.ts
+++ b/src/modules/evm/index.ts
@@ -1,0 +1,20 @@
+import Web3 from 'web3';
+import { TransactionConfig } from 'web3-eth';
+
+export const getRawEvmTransaction = async (
+  web3: Web3,
+  from: string,
+  to: string,
+  data: string,
+  value?: string
+): Promise<TransactionConfig> => {
+  const nonce = await web3.eth.getTransactionCount(from);
+
+  return {
+    nonce,
+    from,
+    to,
+    value: value ? value : '0x0',
+    data,
+  };
+};

--- a/src/v2/services/implementations/MetamaskWalletService.ts
+++ b/src/v2/services/implementations/MetamaskWalletService.ts
@@ -17,6 +17,7 @@ import {
 import { WalletService } from 'src/v2/services/implementations';
 import { Symbols } from 'src/v2/symbols';
 import Web3 from 'web3';
+import { getRawEvmTransaction } from 'src/modules/evm';
 
 @injectable()
 export class MetamaskWalletService extends WalletService implements IWalletService {
@@ -122,16 +123,7 @@ export class MetamaskWalletService extends WalletService implements IWalletServi
   }: ParamSendEvmTransaction): Promise<string> {
     try {
       const web3 = new Web3(this.provider as any);
-      const nonce = await web3.eth.getTransactionCount(from);
-
-      const rawTx = {
-        nonce,
-        from,
-        to,
-        value: value ? value : '0x0',
-        data,
-      };
-
+      const rawTx = await getRawEvmTransaction(web3, from, to, data, value);
       const estimatedGas = await web3.eth.estimateGas(rawTx);
       const transactionHash = await web3.eth
         .sendTransaction({ ...rawTx, gas: estimatedGas })

--- a/src/v2/services/implementations/MetamaskWalletService.ts
+++ b/src/v2/services/implementations/MetamaskWalletService.ts
@@ -122,19 +122,14 @@ export class MetamaskWalletService extends WalletService implements IWalletServi
   }: ParamSendEvmTransaction): Promise<string> {
     try {
       const web3 = new Web3(this.provider as any);
-      const [nonce, gasPrice] = await Promise.all([
-        web3.eth.getTransactionCount(from),
-        web3.eth.getGasPrice(),
-      ]);
+      const nonce = await web3.eth.getTransactionCount(from);
 
-      const multipliedGas = Math.round(Number(gasPrice) * 1.01);
       const rawTx = {
         nonce,
         from,
         to,
         value: value ? value : '0x0',
         data,
-        gasPrice: web3.utils.toHex(multipliedGas.toString()),
       };
 
       const estimatedGas = await web3.eth.estimateGas(rawTx);

--- a/src/v2/services/implementations/XcmEvmService.ts
+++ b/src/v2/services/implementations/XcmEvmService.ts
@@ -73,16 +73,10 @@ export class XcmEvmService implements IXcmEvmService {
         const provider = getEvmProvider(this.currentWallet as any);
         const web3 = new Web3(provider as any);
         const contract = new web3.eth.Contract(ABI as AbiItem[], evmPrecompiledContract.xcm);
-
-        const [nonce, gasPrice] = await Promise.all([
-          web3.eth.getTransactionCount(senderAddress),
-          web3.eth.getGasPrice(),
-        ]);
-        const multipliedGas = Math.round(Number(gasPrice) * 1.01);
+        const nonce = await web3.eth.getTransactionCount(senderAddress);
 
         const rawTx: TransactionConfig = {
           nonce,
-          gasPrice: web3.utils.toHex(multipliedGas.toString()),
           from: senderAddress,
           to: evmPrecompiledContract.xcm,
           value: '0x0',

--- a/src/v2/services/implementations/XcmEvmService.ts
+++ b/src/v2/services/implementations/XcmEvmService.ts
@@ -16,11 +16,11 @@ import { Chain, ethWalletChains } from 'src/v2/models';
 import { IGasPriceProvider, IXcmEvmService, TransferParam } from 'src/v2/services';
 import { Symbols } from 'src/v2/symbols';
 import Web3 from 'web3';
-import { TransactionConfig } from 'web3-eth';
 import { AbiItem } from 'web3-utils';
 import { AlertMsg } from 'src/modules/toast';
 import { getEvmExplorerUrl } from 'src/links';
 import { evmPrecompiledContract } from 'src/modules/precompiled';
+import { getRawEvmTransaction } from 'src/modules/evm';
 
 @injectable()
 export class XcmEvmService implements IXcmEvmService {
@@ -73,25 +73,23 @@ export class XcmEvmService implements IXcmEvmService {
         const provider = getEvmProvider(this.currentWallet as any);
         const web3 = new Web3(provider as any);
         const contract = new web3.eth.Contract(ABI as AbiItem[], evmPrecompiledContract.xcm);
-        const nonce = await web3.eth.getTransactionCount(senderAddress);
-
-        const rawTx: TransactionConfig = {
-          nonce,
-          from: senderAddress,
-          to: evmPrecompiledContract.xcm,
-          value: '0x0',
-          data: contract.methods
-            .assets_withdraw(
-              assetIds,
-              assetAmounts,
-              recipientAccountId,
-              isRelay,
-              parachainId,
-              feeIndex
-            )
-            .encodeABI(),
-        };
-
+        const data = contract.methods
+          .assets_withdraw(
+            assetIds,
+            assetAmounts,
+            recipientAccountId,
+            isRelay,
+            parachainId,
+            feeIndex
+          )
+          .encodeABI();
+        const rawTx = await getRawEvmTransaction(
+          web3,
+          senderAddress,
+          evmPrecompiledContract.xcm,
+          data,
+          '0x0'
+        );
         const estimatedGas = await web3.eth.estimateGas(rawTx);
         await web3.eth
           .sendTransaction({ ...rawTx, gas: estimatedGas })


### PR DESCRIPTION
**Pull Request Summary**

While investigating a lot of weird issues related to EVM transactions on Shibuya (`StakingWithNoValue`, `BalanceLow`...) I figured out that there is no need to provide `gasPrice` when calling `eth.estimateGas` which solved all errors.
Also refactored the code a bit to have single place to build EVM transaction (before we have very similar code on 3 different places).

**Changes affect all EVM transactions on all networks so please test carefully the following EVM transaction: token transfer, XCM transfer, dApp staking, account unification XC20 transfer).**

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
