### PR TITLE
fix: UNQ transfers from Unique Network to Astar

### DIFF
--- a/src/v2/repositories/implementations/xcm/UniqueXcmRepository.ts
+++ b/src/v2/repositories/implementations/xcm/UniqueXcmRepository.ts
@@ -31,7 +31,7 @@ export class UniqueXcmRepository extends XcmRepository {
       throw 'Token must be UNQ';
     }
 
-    const tokenData = { NativeAssetId: 'Here' };
+    const unqCollectionId = 0;
 
     const destination = {
       V2: {
@@ -61,7 +61,7 @@ export class UniqueXcmRepository extends XcmRepository {
       endpoint,
       'xTokens',
       'transfer',
-      tokenData,
+      unqCollectionId,
       amount,
       destination,
       destWeight


### PR DESCRIPTION
**Pull Request Summary**

Fix transfer of UNQ from Unique Network to Astar.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**

Fixed `xtokens.transfer` currency ID argument.

Here is the link to `astar-apps` with the fix already applied: https://poc-apps.aku.uniquenetwork.dev/astar/assets.
20 UNQ was transferred using the `astar-apps` version from the link above. [Subscan XCM Transfer Info](https://astar.subscan.io/xcm_message/astar-863f1b37b61aa23921ff3b3d2298efc461af352f).

The fix is required following the [v10030070](https://github.com/UniqueNetwork/unique-chain/releases/tag/v10030070) Unique Network upgrade, which uses the collection ID type directly as `CurrencyId`.

The collection ID for the native asset (UNQ) is `0`.