### PR TITLE
Display stake/unstake errors

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -705,7 +705,7 @@ export default {
       NoStakingInfo: 'Account has no staking information for the contract',
       NotOperatedDApp: 'dApp is part of dApp staking but is not active anymore.',
       PeriodEndsNextEra:
-        'Period ends in the next era. It is not possible to stake in the last period of an era.',
+        'Period ends in the next era. It is not possible to stake in the last era of an period.',
       TooManyStakedContracts:
         'There are too many contract stake entries for the account. This can be cleaned up by either unstaking or cleaning expired entries.',
       TooManyUnlockingChunks:

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -717,6 +717,7 @@ export default {
       UnstakeFromPastPeriod:
         'Unstaking is rejected since the period in which past stake was active has passed.',
       ZeroAmount: 'Amount must be greater than 0.',
+      LockedAmountBelowThreshold: 'Minimum staking amount is {amount} tokens per dApp.',
     },
     successfullyStaked: 'You successfully staked to {contractAddress}',
     voteTitle: 'Vote!',

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -827,6 +827,8 @@ export default {
     startStakingNow: 'Start Staking Now',
     noEntry: 'No entry',
     burn: 'Burn',
+    willUnstakeAll:
+      'The operation will unstake all of your staked tokens because the minimum staking amount is {amount} tokens.',
   },
   bridge: {
     bridge: 'Bridge',

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -705,7 +705,7 @@ export default {
       NoStakingInfo: 'Account has no staking information for the contract',
       NotOperatedDApp: 'dApp is part of dApp staking but is not active anymore.',
       PeriodEndsNextEra:
-        'Period ends in the next era. It is not possible to stake in the last era of an period.',
+        'Period ends in the next era. It is not possible to stake in the last era of a period.',
       TooManyStakedContracts:
         'There are too many contract stake entries for the account. This can be cleaned up by either unstaking or cleaning expired entries.',
       TooManyUnlockingChunks:

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -445,7 +445,7 @@ export default {
         'All funds will be transferred because the min. staking amount is {minStakingAmount} {symbol}',
       invalidBalance: 'Insufficient transferrable balance to complete the transaction',
       warningLeaveMinAmount:
-        'Account must hold greater than {amount}{symbol} in transferrable when you stake.',
+        'Account must hold amount greater than {amount}{symbol} in transferrable after you stake.',
     },
     maintenance: {
       switching: 'Switching to',
@@ -704,7 +704,8 @@ export default {
       NoExpiredEntries: 'There are no expired entries to clean up.',
       NoStakingInfo: 'Account has no staking information for the contract',
       NotOperatedDApp: 'dApp is part of dApp staking but is not active anymore.',
-      PeriodEndsNextEra: 'Period ends in the next era.',
+      PeriodEndsNextEra:
+        'Period ends in the next era. It is not possible to stake in the last period of an era.',
       TooManyStakedContracts:
         'There are too many contract stake entries for the account. This can be cleaned up by either unstaking or cleaning expired entries.',
       TooManyUnlockingChunks:

--- a/src/staking-v3/components/Dapps.vue
+++ b/src/staking-v3/components/Dapps.vue
@@ -19,7 +19,7 @@
         }"
       >
         <swiper-slide v-for="(dapp, index) in filteredDapps" :key="index">
-          <div v-if="dapp" class="card--dapp" @click="navigateDappPage(dapp.basic.address)">
+          <a v-if="dapp" class="card--dapp" :href="getDappPageUrl(dapp.basic.address)">
             <div class="card__top">
               <div class="icon--dapp">
                 <img :src="dapp.basic.iconUrl" alt="icon" />
@@ -35,7 +35,7 @@
                 <token-balance-native :balance="dapp.chain.totalStake?.toString() ?? '0'" />
               </div>
             </div>
-          </div>
+          </a>
         </swiper-slide>
       </swiper>
     </div>
@@ -47,8 +47,6 @@ import { defineComponent, computed } from 'vue';
 import { useDappStaking, useDappStakingNavigation, useDapps } from '../hooks';
 import TokenBalanceNative from 'src/components/common/TokenBalanceNative.vue';
 import { CombinedDappInfo } from '../logic';
-
-// Import Swiper
 import { Swiper, SwiperSlide } from 'swiper/vue';
 import 'swiper/css';
 
@@ -71,7 +69,7 @@ export default defineComponent({
   setup(props) {
     const { registeredDapps } = useDapps();
     const { getDappTier } = useDappStaking();
-    const { navigateDappPage } = useDappStakingNavigation();
+    const { getDappPageUrl } = useDappStakingNavigation();
 
     const filteredDapps = computed<CombinedDappInfo[]>(() => {
       const dapps = registeredDapps.value.filter(
@@ -89,7 +87,7 @@ export default defineComponent({
       return result;
     });
 
-    return { filteredDapps, getDappTier, navigateDappPage };
+    return { filteredDapps, getDappTier, getDappPageUrl };
   },
 });
 </script>

--- a/src/staking-v3/components/ErrorPanel.vue
+++ b/src/staking-v3/components/ErrorPanel.vue
@@ -1,0 +1,29 @@
+<template>
+  <div v-if="errorMessage" class="error">{{ errorMessage }}</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  props: {
+    errorMessage: {
+      type: String,
+      required: false,
+      default: '',
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.error {
+  border-radius: 16px;
+  border: 1px solid $warning-red;
+  background: $box-red;
+  padding: 16px;
+  color: $white;
+  font-size: 14px;
+  font-weight: 500;
+}
+</style>

--- a/src/staking-v3/components/Owner.vue
+++ b/src/staking-v3/components/Owner.vue
@@ -32,7 +32,7 @@
 
 <script lang="ts">
 import { useNetworkInfo } from 'src/hooks';
-import { computed, defineComponent, watch, ref, onBeforeMount } from 'vue';
+import { computed, defineComponent, watch, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { useDapps, useDappStakingNavigation, useDappStaking, RewardsPerPeriod } from '../hooks';
 import { CombinedDappInfo } from '../logic';
@@ -72,17 +72,13 @@ export default defineComponent({
       }
     };
 
-    onBeforeMount(() => {
-      if (!dapp.value) {
-        navigateToHome();
-      }
-    });
-
     watch(
       [dapp],
       () => {
         if (dapp.value) {
           fetchRewards();
+        } else {
+          navigateToHome();
         }
       },
       { immediate: true }

--- a/src/staking-v3/components/Vote.vue
+++ b/src/staking-v3/components/Vote.vue
@@ -95,6 +95,7 @@
             </div>
           </div>
           <rewards-panel />
+          <div v-if="errorMessage" class="error">{{ errorMessage }}</div>
           <div class="wrapper--button">
             <astar-button
               :disabled="!canConfirm()"
@@ -169,9 +170,16 @@ export default defineComponent({
     RewardsPanel,
   },
   setup() {
-    const { constants, ledger, totalStake, isVotingPeriod, claimLockAndStake } = useDappStaking();
+    const {
+      constants,
+      ledger,
+      totalStake,
+      isVotingPeriod,
+      stakerInfo,
+      canStake,
+      claimLockAndStake,
+    } = useDappStaking();
     const { registeredDapps, getDapp } = useDapps();
-    const { stakerInfo } = useDappStaking();
     const { goBack } = useDappStakingNavigation();
     const { nativeTokenSymbol } = useNetworkInfo();
     const { currentAccount } = useAccount();
@@ -220,13 +228,28 @@ export default defineComponent({
         : availableToMove.value
     );
 
+    const stakeInfo = computed<DappStakeInfo[]>(() => {
+      const stakeInfo: DappStakeInfo[] = [];
+      selectedDapps.value.forEach((dapp) => {
+        if (dapp.amount > 0) {
+          stakeInfo.push({
+            id: dapp.id,
+            address: dapp.address,
+            amount: dapp.amount,
+          });
+        }
+      });
+
+      return stakeInfo;
+    });
+
+    const errorMessage = ref<string>('');
+
     const canConfirm = (): boolean => {
-      // TODO use canStake from useDappStaking after multiple stakes will be supported.
-      return (
-        totalStakeAmount.value > 0 &&
-        availableToVote.value >
-          ethers.utils.parseEther(totalStakeAmount.value.toString()).toBigInt()
-      );
+      const [enabled, message] = canStake(stakeInfo.value, availableToVote.value);
+      errorMessage.value = message;
+
+      return enabled && totalStakeAmount.value > 0;
     };
 
     const handleDappsSelected = (dapps: Dapp[]): void => {
@@ -248,22 +271,11 @@ export default defineComponent({
     const canAddDapp = computed<boolean>((): boolean => selectedDappAddress.value === '');
 
     const confirm = async (): Promise<void> => {
-      const stakeInfo: DappStakeInfo[] = [];
-      selectedDapps.value.forEach((dapp) => {
-        if (dapp.amount > 0) {
-          stakeInfo.push({
-            id: dapp.id,
-            address: dapp.address,
-            amount: dapp.amount,
-          });
-        }
-      });
-
       // If additional funds locking is required remainLockedToken value will be negative.
       // In case of nomination transfer no additional funds locking is required.
       const tokensToLock = remainLockedToken.value + availableToMove.value;
       await claimLockAndStake(
-        stakeInfo,
+        stakeInfo.value,
         tokensToLock < 0 ? tokensToLock * BigInt(-1) : BigInt(0),
         dAppToMoveFromAddress.value,
         amountToUnstake.value
@@ -322,6 +334,7 @@ export default defineComponent({
       isVotingPeriod,
       dAppToMoveTokensFrom,
       availableToMove,
+      errorMessage,
     };
   },
 });

--- a/src/staking-v3/components/Vote.vue
+++ b/src/staking-v3/components/Vote.vue
@@ -205,6 +205,7 @@ export default defineComponent({
       const stakeToken = ethers.utils.parseEther(totalStakeAmount.value.toString()).toBigInt();
       return locked.value - stakeToken - totalStake.value;
     });
+    let remainLockedTokenInitial = BigInt(0);
 
     // Needed to display dApp name and logo on the page.
     const dAppToMoveTokensFrom = computed<CombinedDappInfo | undefined>(() =>
@@ -221,7 +222,7 @@ export default defineComponent({
     });
 
     const availableToVote = computed<bigint>(
-      () => BigInt(useableBalance.value) + max(remainLockedToken.value, BigInt(0))
+      () => BigInt(useableBalance.value) + max(remainLockedTokenInitial, BigInt(0))
     );
 
     const amountToUnstake = computed<bigint>(() =>
@@ -311,6 +312,16 @@ export default defineComponent({
       {
         immediate: true,
       }
+    );
+
+    watch(
+      [remainLockedToken],
+      () => {
+        if (remainLockedTokenInitial === BigInt(0)) {
+          remainLockedTokenInitial = remainLockedToken.value;
+        }
+      },
+      { immediate: true }
     );
 
     return {

--- a/src/staking-v3/components/Vote.vue
+++ b/src/staking-v3/components/Vote.vue
@@ -95,7 +95,7 @@
             </div>
           </div>
           <rewards-panel />
-          <div v-if="errorMessage" class="error">{{ errorMessage }}</div>
+          <error-panel :error-message="errorMessage" />
           <div class="wrapper--button">
             <astar-button
               :disabled="!canConfirm()"
@@ -158,6 +158,7 @@ import { useRoute } from 'vue-router';
 import { CombinedDappInfo, DappStakeInfo } from '../logic';
 import BackToPage from 'src/components/common/BackToPage.vue';
 import RewardsPanel from './RewardsPanel.vue';
+import ErrorPanel from './ErrorPanel.vue';
 import { Path } from 'src/router';
 
 export default defineComponent({
@@ -168,6 +169,7 @@ export default defineComponent({
     ModalSelectDapp,
     BackToPage,
     RewardsPanel,
+    ErrorPanel,
   },
   setup() {
     const {

--- a/src/staking-v3/components/YourRewards.vue
+++ b/src/staking-v3/components/YourRewards.vue
@@ -7,7 +7,7 @@
     <div class="row--claim-temporary">
       <div>
         <span class="text--lg">Unclaimed Eras: </span>
-        <span class="text--lg">--</span>
+        <span class="text--lg">{{ unclaimedEras }}</span>
       </div>
       <div>
         <span class="text--lg">Claimable Amount: </span>
@@ -138,7 +138,7 @@
 <script lang="ts">
 import { useNetworkInfo } from 'src/hooks';
 import { RewardsPerPeriod, useDappStaking } from '../hooks';
-import { defineComponent, PropType } from 'vue';
+import { defineComponent, PropType, computed } from 'vue';
 import TokenBalanceNative from 'src/components/common/TokenBalanceNative.vue';
 
 export default defineComponent({
@@ -157,7 +157,7 @@ export default defineComponent({
       required: true,
     },
   },
-  setup() {
+  setup(props) {
     const { nativeTokenSymbol } = useNetworkInfo();
     const { rewardExpiresInNextPeriod } = useDappStaking();
 
@@ -165,7 +165,11 @@ export default defineComponent({
       return period.toString().padStart(3, '0');
     };
 
-    return { nativeTokenSymbol, formatPeriod, rewardExpiresInNextPeriod };
+    const unclaimedEras = computed<number>(() =>
+      props.rewardsPerPeriod.reduce((acc, cur) => acc + cur.erasToReward, 0)
+    );
+
+    return { nativeTokenSymbol, unclaimedEras, formatPeriod, rewardExpiresInNextPeriod };
   },
 });
 </script>

--- a/src/staking-v3/components/YourRewards.vue
+++ b/src/staking-v3/components/YourRewards.vue
@@ -7,7 +7,9 @@
     <div class="row--claim-temporary">
       <div>
         <span class="text--lg">Unclaimed Eras: </span>
-        <span class="text--lg">{{ unclaimedEras }}</span>
+        <span class="text--lg">
+          <b>{{ unclaimedEras }}</b>
+        </span>
       </div>
       <div>
         <span class="text--lg">Claimable Amount: </span>

--- a/src/staking-v3/components/dapp/DappBackground.vue
+++ b/src/staking-v3/components/dapp/DappBackground.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="wrapper--dapp-background">
-    aaa
     <img class="image--dapp-icon" :src="dapp?.basic.iconUrl" :alt="dapp?.basic.name" />
   </div>
 </template>

--- a/src/staking-v3/components/dapp/DappBackground.vue
+++ b/src/staking-v3/components/dapp/DappBackground.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="wrapper--dapp-background">
     aaa
-    <img class="image--dapp-icon" :src="dapp.basic.iconUrl" :alt="dapp.basic.name" />
+    <img class="image--dapp-icon" :src="dapp?.basic.iconUrl" :alt="dapp?.basic.name" />
   </div>
 </template>
 <script lang="ts">

--- a/src/staking-v3/components/dapp/DappV3.vue
+++ b/src/staking-v3/components/dapp/DappV3.vue
@@ -43,7 +43,7 @@ import { Path } from 'src/router';
 import { useStore } from 'src/store';
 import { container } from 'src/v2/common';
 import { Symbols } from 'src/v2/symbols';
-import { computed, defineComponent, watch, onBeforeMount, ref, onMounted } from 'vue';
+import { computed, defineComponent, watch, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { useDapps, useDappStakingNavigation } from '../../hooks';
 import { CombinedDappInfo, IDappStakingRepository } from 'src/staking-v3/logic';
@@ -100,17 +100,13 @@ export default defineComponent({
       }
     };
 
-    onBeforeMount(() => {
-      if (!dapp.value) {
-        navigateToHome();
-      }
-    });
-
     watch(
       [dapp, registeredDapps],
       () => {
-        if (dapp != undefined) {
+        if (dapp.value != undefined) {
           getDappFromApi();
+        } else if (registeredDapps.value.length > 0 && dapp.value === undefined) {
+          navigateToHome();
         }
       },
       { immediate: true }

--- a/src/staking-v3/components/my-staking/ModalUnbondDapp.vue
+++ b/src/staking-v3/components/my-staking/ModalUnbondDapp.vue
@@ -1,7 +1,7 @@
 <template>
   <modal-wrapper
     :is-modal-open="show"
-    :title="$t('dappStaking.modals.unbondFrom', { name: dapp?.name })"
+    :title="$t('dappStaking.modals.unbondFrom', { name: dapp?.basic.name })"
     :is-closing="isClosingModal"
     :close-modal="closeModal"
   >
@@ -52,7 +52,7 @@
         :set-selected-gas="setSelectedTip"
       />
 
-      <rewards-panel />
+      <rewards-panel class="panel" />
 
       <div class="warning">
         <li>
@@ -61,23 +61,8 @@
           }}
         </li>
       </div>
-
-      <div
-        v-if="isBelowThanMinStaking"
-        class="row--box-error box--error"
-        data-testid="warning-unstake-all-balance"
-      >
-        <span class="color--white">
-          {{
-            $t('dappStaking.willUnstakeAll', {
-              minStakingAmount: $n(truncate(minStakingAmount)),
-              symbol: nativeTokenSymbol,
-            })
-          }}
-        </span>
-      </div>
-
-      <astar-button class="unbond-button" :disabled="!canUnbond" @click="unbound()"
+      <error-panel :error-message="errorMessage" class="panel" />
+      <astar-button class="unbond-button" :disabled="!canUnbond()" @click="unbound()"
         >{{ $t('dappStaking.modals.startUnbonding') }}
       </astar-button>
     </div>
@@ -98,12 +83,14 @@ import { useStore } from 'src/store';
 import { CombinedDappInfo } from 'src/staking-v3/logic';
 import { useDappStaking } from 'src/staking-v3/hooks';
 import RewardsPanel from '../RewardsPanel.vue';
+import ErrorPanel from '../ErrorPanel.vue';
 
 export default defineComponent({
   components: {
     SpeedConfiguration,
     ModalWrapper,
     RewardsPanel,
+    ErrorPanel,
   },
   props: {
     show: {
@@ -125,18 +112,16 @@ export default defineComponent({
     const nativeTokenImg = computed<string>(() =>
       getTokenImage({ isNativeToken: true, symbol: nativeTokenSymbol.value })
     );
-    const { stakerInfo, constants, unstake } = useDappStaking();
+    const { stakerInfo, constants, unstake, canUnStake } = useDappStaking();
     const store = useStore();
 
     const minStakingAmount = computed<number>(() => {
       const amt = store.getters['dapps/getMinimumStakingAmount'];
       return Number(ethers.utils.formatEther(amt));
     });
-
     const isBelowThanMinStaking = computed<boolean>(() => {
       return minStakingAmount.value > Number(maxAmount.value) - Number(amount.value);
     });
-
     const maxAmount = computed<string>(() => {
       const selectedDappStakes = stakerInfo.value?.get(props.dapp.chain.address);
 
@@ -145,6 +130,7 @@ export default defineComponent({
         : '0';
     });
     const amount = ref<string | null>(null);
+    const errorMessage = ref<string | undefined>();
 
     const toMaxAmount = (): void => {
       amount.value = truncate(maxAmount.value).toString();
@@ -162,14 +148,16 @@ export default defineComponent({
       isClosingModal.value = false;
     };
 
-    const canUnbond = computed<boolean>(() => {
-      return Number(amount?.value ?? 0) > 0;
-    });
+    const canUnbond = () => {
+      const [result, message] = canUnStake(props.dapp.basic.address, Number(amount.value));
+      errorMessage.value = message;
+
+      return result;
+    };
 
     const unbound = async (): Promise<void> => {
       await closeModal();
       const unstakeAmount = isBelowThanMinStaking.value ? maxAmount.value : amount.value;
-
       if (unstakeAmount) {
         await unstake(props.dapp, Number(unstakeAmount));
       } else {
@@ -184,7 +172,6 @@ export default defineComponent({
       amount,
       selectedTip,
       nativeTipPrice,
-      isBelowThanMinStaking,
       minStakingAmount,
       isClosingModal,
       setSelectedTip,
@@ -196,6 +183,7 @@ export default defineComponent({
       canUnbond,
       closeModal,
       constants,
+      errorMessage,
     };
   },
 });
@@ -209,6 +197,7 @@ export default defineComponent({
   flex-direction: column;
   align-items: center;
   padding-bottom: 36px;
+  padding-left: 20px;
   @media (min-width: $md) {
     padding-bottom: 0px;
   }
@@ -256,11 +245,10 @@ export default defineComponent({
   border-radius: 6px;
   padding: 8px;
   margin-top: 20px;
-  margin-bottom: 40px;
   margin-bottom: 20px;
   width: 344px;
   @media (min-width: $md) {
-    width: 400px;
+    width: 410px;
   }
 }
 
@@ -279,6 +267,14 @@ export default defineComponent({
   margin-top: 20px;
   @media (min-width: $md) {
     width: 400px;
+  }
+}
+
+.panel {
+  border-radius: 6px;
+  width: 344px;
+  @media (min-width: $md) {
+    width: 410px;
   }
 }
 </style>

--- a/src/staking-v3/components/styles/dapps.scss
+++ b/src/staking-v3/components/styles/dapps.scss
@@ -21,7 +21,6 @@
 .card--dapp {
   border: 1px solid $navy-1;
   border-radius: 16px;
-  cursor: pointer;
   display: flex;
   flex-direction: column;
   transition: all 0.2s ease;

--- a/src/staking-v3/components/styles/vote.scss
+++ b/src/staking-v3/components/styles/vote.scss
@@ -218,3 +218,13 @@ li {
 .nomination--balance {
   margin-left: auto;
 }
+
+.error {
+  border-radius: 16px;
+  border: 1px solid $warning-red;
+  background: $box-red;
+  padding: 16px;
+  color: $white;
+  font-size: 14px;
+  font-weight: 500;
+}

--- a/src/staking-v3/hooks/useDappStaking.ts
+++ b/src/staking-v3/hooks/useDappStaking.ts
@@ -25,7 +25,6 @@ import { useI18n } from 'vue-i18n';
 import { useDapps } from './useDapps';
 import { ethers } from 'ethers';
 
-import BN from 'bn.js';
 import { initialDappTiersConfiguration, initialTiersConfiguration } from '../store/state';
 import { checkIsDappStakingV3 } from 'src/modules/dapp-staking';
 import { ApiPromise } from '@polkadot/api';
@@ -371,52 +370,51 @@ export function useDappStaking() {
     store.commit('stakingV3/setCurrentEraInfo', eraInfo);
   };
 
-  const canStake = async (
-    dappAddress: string,
-    amount: number,
-    ignoreCanClaim = false
-  ): Promise<[boolean, string]> => {
-    const stakeAmount = new BN(ethers.utils.parseEther(amount.toString()).toString());
-    const balanceBN = new BN(useableBalance.value.toString());
-    const stakingRepo = container.get<IDappStakingRepository>(Symbols.DappStakingRepositoryV3);
-    const constants = await stakingRepo.getConstants();
+  const canStake = (stakes: DappStakeInfo[], availableTokensBalance: bigint): [boolean, string] => {
+    let stakeSum = BigInt(0);
 
-    if (!dappAddress) {
-      // Prevents NoDappSelected
-      return [false, t('stakingV3.noDappSelected')];
-    } else if (amount <= 0) {
-      // Prevents dappStaking.ZeroAmount
-      return [false, t('stakingV3.dappStaking.ZeroAmount')];
-    } else if ((ledger.value?.contractStakeCount ?? 0) >= constants.maxNumberOfStakedContracts) {
-      // Prevents dappStaking.TooManyStakedContracts
-      return [false, t('stakingV3.dappStaking.TooManyStakedContracts')];
-    } else if (hasRewards.value && !ignoreCanClaim) {
-      // Prevents dappStaking.UnclaimedRewards
-      // May want to auto claim rewards here
-      return [false, t('stakingV3.dappStaking.UnclaimedRewards')];
-    } else if (protocolState.value?.maintenance) {
-      // Prevents dappStaking.Disabled
-      return [false, t('stakingV3.dappStaking.Disabled')];
-    } else if (stakeAmount.gt(balanceBN)) {
-      // Prevents dappStaking.UnavailableStakeFunds
-      return [false, t('stakingV3.dappStaking.UnavailableStakeFunds')];
-    } else if (
-      protocolState.value?.periodInfo.subperiod === PeriodType.BuildAndEarn &&
-      protocolState.value.periodInfo.nextSubperiodStartEra <= protocolState.value.era + 1
-    ) {
-      // Prevents dappStaking.PeriodEndsInNextEra
-      return [false, t('stakingV3.dappStaking.PeriodEndsNextEra')];
-    } else if (getDapp(dappAddress)?.chain?.state === 'Unregistered') {
-      // Prevents dappStaking.NotOperatedDApp
-      return [false, t('stakingV3.dappStaking.NotOperatedDApp')];
+    for (const stake of stakes) {
+      const stakeAmount = BigInt(ethers.utils.parseEther(stake.amount.toString()).toString());
+      stakeSum += stakeAmount;
+      if (!stake.address) {
+        return [false, t('stakingV3.noDappSelected')];
+      } else if (stake.amount <= 0) {
+        return [false, t('stakingV3.dappStaking.ZeroAmount')];
+      } else if (
+        constants.value &&
+        (ledger.value?.contractStakeCount ?? 0) >= constants.value.maxNumberOfStakedContracts
+      ) {
+        return [false, t('stakingV3.dappStaking.TooManyStakedContracts')];
+      } else if (
+        constants.value?.minStakeAmountToken &&
+        stake.amount < constants.value.minStakeAmountToken
+      ) {
+        return [
+          false,
+          t('stakingV3.dappStaking.LockedAmountBelowThreshold', {
+            amount: constants.value.minStakeAmountToken,
+          }),
+        ];
+      } else if (protocolState.value?.maintenance) {
+        return [false, t('stakingV3.dappStaking.Disabled')];
+      } else if (stakeSum > availableTokensBalance) {
+        return [false, t('stakingV3.dappStaking.UnavailableStakeFunds')];
+      } else if (
+        protocolState.value?.periodInfo.subperiod === PeriodType.BuildAndEarn &&
+        protocolState.value.periodInfo.nextSubperiodStartEra <= protocolState.value.era + 1
+      ) {
+        return [false, t('stakingV3.dappStaking.PeriodEndsNextEra')];
+      } else if (getDapp(stake.address)?.chain?.state === 'Unregistered') {
+        return [false, t('stakingV3.dappStaking.NotOperatedDApp')];
+      }
     }
 
     return [true, ''];
   };
 
   const canUnStake = async (dappAddress: string, amount: number): Promise<[boolean, string]> => {
-    const stakeAmount = new BN(ethers.utils.parseEther(amount.toString()).toString());
-    const stakedAmount = new BN(ledger.value?.locked?.toString() ?? 0);
+    const stakeAmount = BigInt(ethers.utils.parseEther(amount.toString()).toString());
+    const stakedAmount = BigInt(ledger.value?.locked?.toString() ?? 0);
     const stakingRepo = container.get<IDappStakingRepository>(Symbols.DappStakingRepositoryV3);
     const [constants, stakerInfo] = await Promise.all([
       stakingRepo.getConstants(),
@@ -426,7 +424,7 @@ export function useDappStaking() {
     if (amount <= 0) {
       // Prevents dappStaking.ZeroAmount
       return [false, t('stakingV3.dappStaking.ZeroAmount')];
-    } else if (stakeAmount.gt(stakedAmount)) {
+    } else if (stakeAmount > stakedAmount) {
       // Prevents dappStaking.UnstakeAmountTooLarge
       return [false, t('stakingV3.dappStaking.UnstakeAmountTooLarge')];
     } else if (protocolState.value?.maintenance) {

--- a/src/staking-v3/hooks/useDappStakingNavigation.ts
+++ b/src/staking-v3/hooks/useDappStakingNavigation.ts
@@ -20,9 +20,12 @@ export function useDappStakingNavigation() {
   };
 
   const navigateDappPage = (address: string): void => {
+    router.push(getDappPageUrl(address));
+  };
+
+  const getDappPageUrl = (address: string): string => {
     const base = networkParam + Path.DappStaking + Path.Dapp;
-    const url = `${base}?dapp=${address?.toLowerCase()}`;
-    router.push(url);
+    return `${base}?dapp=${address?.toLowerCase()}`;
   };
 
   const goBack = () => router.go(-1);
@@ -37,6 +40,7 @@ export function useDappStakingNavigation() {
     navigateToHome,
     navigateDappPage,
     navigateOwnerPage,
+    getDappPageUrl,
     goBack,
   };
 }

--- a/tests/test_specs/dappstaking-transactions.spec.ts
+++ b/tests/test_specs/dappstaking-transactions.spec.ts
@@ -77,7 +77,7 @@ test.describe('dApp staking transactions', () => {
       page
         .locator('div')
         .filter({
-          hasText: /^Account must hold greater than 10ASTR in transferrable when you stake\.$/,
+          hasText: /^Account must hold amount greater than 10ASTR in transferrable after you stake\.$/,
         })
         .locator('span')
     ).toBeVisible();


### PR DESCRIPTION
**Pull Request Summary**

- Updated canStake and canUnstake methods logic and Vote/Unstake components to display errors to an user.
- Enable opening a dApp page in a new tab
- Show number of unclaimed eras on dApp owner page

![image](https://github.com/AstarNetwork/astar-apps/assets/8452361/a8ed1da3-1a6d-4dc8-a849-f2c798f19d29)
<img width="485" alt="image" src="https://github.com/AstarNetwork/astar-apps/assets/8452361/a604a270-67d7-4ebb-96ff-3d4e867f56c8">
<img width="505" alt="image" src="https://github.com/AstarNetwork/astar-apps/assets/8452361/4907df63-abd8-44a8-a9d0-0a3d86235258">


**Check list**

- [ ] contains breaking changes
- [x] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
