### PR TITLE
fix vote/stake modal height

### DIFF
--- a/src/staking-v3/components/dapp-selector/ModalSelectDapp.vue
+++ b/src/staking-v3/components/dapp-selector/ModalSelectDapp.vue
@@ -164,10 +164,14 @@ export default defineComponent({
   margin: 8px 0;
   cursor: pointer;
   border: 1px solid transparent;
+  transition: all 0.2s ease;
+  &:hover {
+    border-color: $astar-blue;
+  }
 }
 
 .selected--dapp {
-  border: 1px solid $astar-blue;
+  border-color: $astar-blue;
 }
 
 .selection--order {

--- a/src/staking-v3/components/dapp-selector/ModalSelectDapp.vue
+++ b/src/staking-v3/components/dapp-selector/ModalSelectDapp.vue
@@ -28,12 +28,14 @@
           {{ getDappSelectionNumber(dapp) }}
         </div>
       </div>
-      <astar-button
-        :disabled="selectedDapps.length === 0"
-        class="button--primary"
-        @click="handleDone()"
-        >{{ $t('stakingV3.done') }}</astar-button
-      >
+      <div class="container--btn">
+        <astar-button
+          :disabled="selectedDapps.length === 0"
+          class="button--primary"
+          @click="handleDone()"
+          >{{ $t('stakingV3.done') }}</astar-button
+        >
+      </div>
     </div>
   </modal-wrapper>
 </template>
@@ -139,9 +141,11 @@ export default defineComponent({
   font-style: normal;
   font-weight: 600;
   line-height: normal;
-  padding: 0 35px 35px 35px;
+  margin: 0 35px 35px 35px;
+  max-height: 70vh;
+  overflow-y: auto;
   @media (min-width: $sm) {
-    padding: 0;
+    margin: 0;
   }
 }
 
@@ -182,14 +186,28 @@ export default defineComponent({
   display: flex;
 }
 
+.container--btn {
+  margin-top: 24px;
+  position: sticky;
+  bottom: 0;
+  background-color: white;
+}
+
+.body--dark {
+  .container--btn {
+    background-color: $navy-1;
+  }
+}
+
 .button--primary {
   width: 100%;
   height: 52px;
-  margin-top: 24px;
 }
 
 .search {
   margin-bottom: 24px;
+  position: sticky;
+  top: 0;
   input {
     outline: none;
     width: 100%;


### PR DESCRIPTION
**Pull Request Summary**

- Added max height to the vote/stake modal
- The search form will stick to the top
- The button will stick to the bottom

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**

<img width="1274" alt="Screenshot 2024-01-15 at 5 48 12 PM" src="https://github.com/AstarNetwork/astar-apps/assets/33358068/98191aae-e9d5-47bc-9153-899f33b0ec46">