### PR TITLE
hotfix: adjust claim warning banner style

### DIFF
--- a/src/components/assets/styles/account.scss
+++ b/src/components/assets/styles/account.scss
@@ -216,7 +216,7 @@
   background-color: white;
   padding: 16px;
   min-height: 180px;
-  @media (min-width: $lg) {
+  @media (min-width: $sm) {
     border-radius: 16px;
     margin: 0;
   }

--- a/src/components/assets/styles/account.scss
+++ b/src/components/assets/styles/account.scss
@@ -4,10 +4,6 @@
   display: flex;
   flex-direction: column;
   gap: 32px;
-  margin-top: -36px;
-  @media (min-width: $lg) {
-    margin-top: 0;
-  }
 }
 
 .row--details-signatory {

--- a/src/components/dapp-staking/StakingTop.vue
+++ b/src/components/dapp-staking/StakingTop.vue
@@ -124,7 +124,7 @@ export default defineComponent({
 
 .container--main {
   width: 100%;
-  padding: 0px 0px 24px 0px;
+  padding: 48px 0 24px 0px;
   margin: 0 auto;
 
   @media (min-width: $md) {
@@ -133,9 +133,6 @@ export default defineComponent({
 
   @media (min-width: $widthCardLineUp) {
     max-width: 100%;
-  }
-  @media (min-width: $lg) {
-    margin-top: 50px;
   }
 }
 

--- a/src/components/header/ClaimWarningBanner.vue
+++ b/src/components/header/ClaimWarningBanner.vue
@@ -29,6 +29,8 @@ export default defineComponent({
   padding: 4px 16px 8px 16px;
   line-height: 1.25;
   font-size: 12px;
+  position: relative;
+  z-index: 1;
   @media (min-width: $sm) {
     font-size: 14px;
   }

--- a/src/components/header/Header.vue
+++ b/src/components/header/Header.vue
@@ -24,8 +24,6 @@
       <mobile-nav v-if="width <= screenSize.lg" />
     </header-comp>
 
-    <claim-warning-banner :network="currentNetworkIdx" />
-
     <!-- Modals -->
     <modal-network
       v-if="modalNetwork"
@@ -130,7 +128,6 @@ export default defineComponent({
     ModalPolkasafe,
     ModalAccountUnification,
     MobileNav,
-    ClaimWarningBanner,
   },
   setup() {
     const { width, screenSize } = useBreakpoints();

--- a/src/components/header/Header.vue
+++ b/src/components/header/Header.vue
@@ -108,7 +108,6 @@ import { container } from 'src/v2/common';
 import { IEventAggregator, UnifyAccountMessage } from 'src/v2/messaging';
 import { Symbols } from 'src/v2/symbols';
 import { isValidAddressPolkadotAddress } from '@astar-network/astar-sdk-core';
-import ClaimWarningBanner from './ClaimWarningBanner.vue';
 
 interface Modal {
   modalNetwork: boolean;

--- a/src/layouts/DashboardLayout.vue
+++ b/src/layouts/DashboardLayout.vue
@@ -5,6 +5,7 @@
     </template>
     <div class="wrapper--dashboard-layout__inner">
       <portal-header />
+      <claim-warning-banner :network="currentNetworkIdx" />
       <main id="assets-top" class="wrapper--main">
         <div class="wrapper--components">
           <slot />
@@ -15,18 +16,20 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, watchEffect } from 'vue';
+import { defineComponent, watchEffect, computed } from 'vue';
 import { useBreakpoints, useGasPrice } from 'src/hooks';
 import PortalHeader from 'src/components/header/Header.vue';
 import SidebarDesktop from 'components/sidenav/SidebarDesktop.vue';
 import { useQuasar } from 'quasar';
 import { LOCAL_STORAGE } from 'src/config/localStorage';
 import { useStore } from 'src/store';
+import ClaimWarningBanner from 'src/components/header/ClaimWarningBanner.vue';
 
 export default defineComponent({
   components: {
     PortalHeader,
     SidebarDesktop,
+    ClaimWarningBanner,
   },
   setup() {
     const store = useStore();
@@ -46,9 +49,12 @@ export default defineComponent({
     const isFetchGas = true;
     useGasPrice(isFetchGas);
 
+    const currentNetworkIdx = computed<number>(() => store.getters['general/networkIdx']);
+
     return {
       width,
       screenSize,
+      currentNetworkIdx,
     };
   },
 });


### PR DESCRIPTION
**Pull Request Summary**

Fixed the claim warning banner covering the account area on the mobile screen size.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**

|Before|After|
|-|-|
|<img width="407" alt="Screenshot 2024-01-16 at 11 39 16 AM" src="https://github.com/AstarNetwork/astar-apps/assets/33358068/6239a84e-653e-4b12-a4ce-eb89ad0aecfb">|<img width="414" alt="Screenshot 2024-01-16 at 11 38 08 AM" src="https://github.com/AstarNetwork/astar-apps/assets/33358068/e4fb6665-773b-46e3-9507-e5c5353b4a3e">|