### PR TITLE
Handle removal of unregistered dApps from a node storage

### DIFF
--- a/src/staking-v3/hooks/useLeaderboard.ts
+++ b/src/staking-v3/hooks/useLeaderboard.ts
@@ -24,7 +24,7 @@ export function useLeaderboard() {
   );
 
   const sortedDapps = computed<CombinedDappInfo[]>(() =>
-    registeredDapps.value.sort((a, b) => {
+    [...registeredDapps.value].sort((a, b) => {
       const valueA = a.chain?.totalStake ?? BigInt(0);
       const valueB = b.chain?.totalStake ?? BigInt(0);
 

--- a/src/staking-v3/logic/interfaces/DappStakingV3.ts
+++ b/src/staking-v3/logic/interfaces/DappStakingV3.ts
@@ -58,7 +58,6 @@ export interface PalletDappStakingV3ProtocolState extends Struct {
 export interface PalletDappStakingV3DAppInfo extends Struct {
   readonly owner: AccountId32;
   readonly id: Compact<u16>;
-  readonly state: PalletDappStakingV3DAppState;
   readonly rewardBeneficiary: Option<AccountId32>;
 }
 

--- a/src/staking-v3/logic/models/DappStaking.ts
+++ b/src/staking-v3/logic/models/DappStaking.ts
@@ -1,4 +1,4 @@
-import { DappInfo, ProtocolState } from './Node';
+import { DappInfo, DappState, ProtocolState } from './Node';
 import { Community } from '@astar-network/astar-sdk-core';
 
 /**
@@ -198,6 +198,9 @@ export interface ProviderDappData {
   registrationBlockNumber: number;
   unregisteredAt?: number;
   unregistrationBlockNumber?: number;
+  owner: string;
+  beneficiary?: string;
+  state: DappState;
 }
 
 export interface StakerRewards {

--- a/src/staking-v3/logic/models/DappStaking.ts
+++ b/src/staking-v3/logic/models/DappStaking.ts
@@ -201,6 +201,7 @@ export interface ProviderDappData {
   owner: string;
   beneficiary?: string;
   state: DappState;
+  dappId: number;
 }
 
 export interface StakerRewards {

--- a/src/staking-v3/logic/repositories/DappStakingRepository.ts
+++ b/src/staking-v3/logic/repositories/DappStakingRepository.ts
@@ -517,7 +517,7 @@ export class DappStakingRepository implements IDappStakingRepository {
       address,
       owner: dapp.owner.toString(),
       id: dapp.id.toNumber(),
-      state: dapp.state.isUnregistered ? DappState.Unregistered : DappState.Registered,
+      state: DappState.Registered, // All dApss from integratedDApps are registered.
       rewardDestination: dapp.rewardBeneficiary.unwrapOr(undefined)?.toString(),
     };
   }

--- a/src/staking-v3/logic/services/DappStakingService.ts
+++ b/src/staking-v3/logic/services/DappStakingService.ts
@@ -72,7 +72,7 @@ export class DappStakingService implements IDappStakingService {
             dappDetails: dapp,
             chain: {
               address: dapp.contractAddress,
-              id: -1, // TODO update
+              id: dapp.dappId,
               owner: dapp.owner,
               state: DappState.Unregistered,
             },

--- a/src/staking-v3/logic/services/DappStakingService.ts
+++ b/src/staking-v3/logic/services/DappStakingService.ts
@@ -3,6 +3,7 @@ import {
   CombinedDappInfo,
   DappInfo,
   DappStakeInfo,
+  DappState,
   SingularStakingInfo,
   StakeAmount,
   StakerRewards,
@@ -37,7 +38,7 @@ export class DappStakingService implements IDappStakingService {
       this.tokenApiRepository.getDapps(network.toLowerCase()),
     ]);
 
-    // Map on chain and in store dApps
+    // Map on chain and in store dApps (registered only)
     const dApps: CombinedDappInfo[] = [];
     const onlyChain: DappInfo[] = [];
     chainDapps.forEach((chainDapp) => {
@@ -57,6 +58,27 @@ export class DappStakingService implements IDappStakingService {
         onlyChain.push(chainDapp);
       }
     });
+
+    // Map unregistered dApps
+    tokenApiDapps
+      .filter((x) => x.state === 'Unregistered')
+      .forEach((dapp) => {
+        const storeDapp = storeDapps.find(
+          (x) => x.address.toLowerCase() === dapp.contractAddress.toLowerCase()
+        );
+        if (storeDapp) {
+          dApps.push({
+            basic: storeDapp,
+            dappDetails: dapp,
+            chain: {
+              address: dapp.contractAddress,
+              id: -1, // TODO update
+              owner: dapp.owner,
+              state: DappState.Unregistered,
+            },
+          });
+        }
+      });
 
     return { fullInfo: dApps, chainInfo: onlyChain };
   }


### PR DESCRIPTION
**Pull Request Summary**

**Deploy after next Shibuya runtime upgrade**

This PR is to support breaking changes in runtime https://github.com/AstarNetwork/Astar/pull/1153

Unregistered dApps are removed from `integratedDApps` storage item and UI lost info about unregistered dApps. Also `state` field is removed from `DAppInfo ` structure.
I decided to use dApp data from indexer to fetch unregistered dApps info. 

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
