### PR TITLE
Fix scroll animation

### DIFF
--- a/src/staking-v3/components/leaderboard/styles/leaderboard.scss
+++ b/src/staking-v3/components/leaderboard/styles/leaderboard.scss
@@ -36,7 +36,7 @@
   right: 0;
   z-index: 0;
   animation: parallax-small-anim linear;
-  animation-timeline: scroll();
+  animation-timeline: scroll() !important;
   img {
     width: 100%;
   }

--- a/src/staking-v3/components/styles/feature-dapp.scss
+++ b/src/staking-v3/components/styles/feature-dapp.scss
@@ -16,7 +16,7 @@
   position: relative;
   z-index: 1;
   animation: parallax-small-anim linear;
-  animation-timeline: scroll();
+  animation-timeline: scroll() !important;
   @media (min-width: $lg) {
     padding: 0;
   }


### PR DESCRIPTION
**Pull Request Summary**

- Fixed the background image scroll animation

It worked in the local env but didn't work after deployment to the server. Still, I don't know why this happened, but adding `!important` to CSS fixed it.

I'm using a new CSS property [animation-timeline](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timeline), and it works only on Chrome.

https://www.loom.com/share/b3738834bb18412e92270d831f748140?sid=446c5940-f801-43fe-b17b-7a11279e2b60

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices