### PR TITLE
Add text ellipsis to the dApp cards

### DIFF
--- a/src/staking-v3/components/DynamicAdsArea.vue
+++ b/src/staking-v3/components/DynamicAdsArea.vue
@@ -95,3 +95,29 @@ export default defineComponent({
 <style lang="scss" scoped>
 @import './styles/ads-area.scss';
 </style>
+
+<style lang="scss">
+.swiper--ads-area {
+  .swiper-button-prev,
+  .swiper-button-next {
+    color: white;
+    width: 40px;
+    height: 40px;
+    border-radius: 20px;
+    background-color: $navy-1;
+    &::after {
+      font-size: 12px;
+      font-weight: 600;
+    }
+  }
+  .swiper-button-prev {
+    padding-right: 2px;
+  }
+  .swiper-button-next {
+    padding-left: 2px;
+  }
+  .swiper-button-disabled {
+    display: none;
+  }
+}
+</style>

--- a/src/staking-v3/components/dapp/DappAvatar.vue
+++ b/src/staking-v3/components/dapp/DappAvatar.vue
@@ -1,15 +1,15 @@
 <template>
   <div :class="`wrapper--dapp-avatar ${small ? 'small' : ''}`">
     <div class="column--avatar">
-      <div>
-        <img class="image--dapp-icon" :src="dapp.extended?.iconUrl" :alt="dapp.extended?.name" />
+      <div class="image--dapp-icon">
+        <img :src="dapp.extended?.iconUrl" :alt="dapp.extended?.name" />
       </div>
       <div class="column--details">
         <div class="row--dapp-title">
           {{ dapp.extended?.name }}
         </div>
         <div v-if="!small" class="row--dapp-description">
-          {{ dapp.extended?.description }}
+          {{ dapp.extended?.shortDescription }}
         </div>
         <div v-if="dapp.extended?.tags && !small" class="row--tags">
           <div v-for="tag in dapp.extended?.tags" :key="tag" class="tag">

--- a/src/staking-v3/components/dapp/styles/builders.scss
+++ b/src/staking-v3/components/dapp/styles/builders.scss
@@ -67,11 +67,16 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   @media (min-width: $sm) {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
   @media (min-width: $lg) {
-    display: flex;
-    flex-wrap: wrap;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  @media (min-width: $xl) {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+  @media (min-width: $xxl) {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
   }
 }
 
@@ -84,7 +89,6 @@
   flex-direction: column;
   gap: 12px;
   @media (min-width: $lg) {
-    width: 200px;
     padding: 24px 32px;
   }
 }

--- a/src/staking-v3/components/dapp/styles/dapp-avatar.scss
+++ b/src/staking-v3/components/dapp/styles/dapp-avatar.scss
@@ -22,12 +22,15 @@
 }
 
 .image--dapp-icon {
-  width: 120px;
-  height: 120px;
-  border-radius: 16px;
-  object-fit: contain;
-  overflow: hidden;
-  margin: auto;
+  flex-shrink: 0;
+  img {
+    width: 120px;
+    height: 120px;
+    border-radius: 16px;
+    object-fit: contain;
+    overflow: hidden;
+    margin: auto;
+  }
 }
 
 .row--dapp-title {
@@ -129,11 +132,13 @@
     }
   }
   .image--dapp-icon {
-    width: 44px;
-    height: 44px;
-    @media (min-width: $sm) {
-      width: 60px;
-      height: 60px;
+    img {
+      width: 44px;
+      height: 44px;
+      @media (min-width: $sm) {
+        width: 60px;
+        height: 60px;
+      }
     }
   }
   .row--dapp-title {

--- a/src/staking-v3/components/styles/dapps.scss
+++ b/src/staking-v3/components/styles/dapps.scss
@@ -88,14 +88,24 @@
 .text--title {
   font-weight: 700;
   font-size: 16px;
-  margin: 12px 0 8px 0;
+  margin: 0 0 4px 0;
   line-height: 1.25;
+  overflow: hidden;
+  display: -webkit-box;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
 }
 
 .text--description {
   color: $navy-4;
   font-size: 12px;
   font-weight: 500;
+  overflow: hidden;
+  display: -webkit-box;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
 }
 
 .card__bottom {

--- a/src/staking-v3/components/styles/dapps.scss
+++ b/src/staking-v3/components/styles/dapps.scss
@@ -91,18 +91,21 @@
   margin: 0 0 4px 0;
   line-height: 1.25;
   overflow: hidden;
+  display: -webkit-box;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
 }
 
 .text--description {
   color: $navy-4;
   font-size: 12px;
   font-weight: 500;
+  overflow: hidden;
   display: -webkit-box;
+  text-overflow: ellipsis;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
-  overflow: hidden;
 }
 
 .card__bottom {
@@ -124,15 +127,15 @@
   gap: 8px;
   align-items: center;
   height: 28px;
-  span {
+  span{
     display: flex;
     align-items: center;
-    .icon--stakers {
+    .icon--stakers{
       width: 24px;
       height: 24px;
       margin-bottom: -10px;
     }
-    .icon--astar-logo {
+    .icon--astar-logo{
       width: 18px;
       height: 18px;
       margin-right: 4px;

--- a/src/staking-v3/components/styles/dapps.scss
+++ b/src/staking-v3/components/styles/dapps.scss
@@ -91,21 +91,18 @@
   margin: 0 0 4px 0;
   line-height: 1.25;
   overflow: hidden;
-  display: -webkit-box;
   text-overflow: ellipsis;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
+  white-space: nowrap;
 }
 
 .text--description {
   color: $navy-4;
   font-size: 12px;
   font-weight: 500;
-  overflow: hidden;
   display: -webkit-box;
-  text-overflow: ellipsis;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
+  overflow: hidden;
 }
 
 .card__bottom {
@@ -127,15 +124,15 @@
   gap: 8px;
   align-items: center;
   height: 28px;
-  span{
+  span {
     display: flex;
     align-items: center;
-    .icon--stakers{
+    .icon--stakers {
       width: 24px;
       height: 24px;
       margin-bottom: -10px;
     }
-    .icon--astar-logo{
+    .icon--astar-logo {
       width: 18px;
       height: 18px;
       margin-right: 4px;


### PR DESCRIPTION
**Pull Request Summary**

- Added text ellipsis to the dApp cards:
  - dApp title -> 1 line
  - dApp description -> 3 lines

<img width="660" alt="Screenshot 2024-02-13 at 11 32 08 AM" src="https://github.com/AstarNetwork/astar-apps/assets/33358068/3d6da7f1-daee-4bca-b5a4-ae4ad70b4f52">

- Fixed the arrow style of the ads section

<img width="1400" alt="Screenshot 2024-02-13 at 11 35 04 AM" src="https://github.com/AstarNetwork/astar-apps/assets/33358068/25a6f7b0-f687-498f-866a-e460abab4bb7">

- Fixed the unwanted space of the dApp builders.

<img width="1301" alt="Screenshot 2024-02-13 at 11 40 05 AM" src="https://github.com/AstarNetwork/astar-apps/assets/33358068/cec21e76-9660-4c49-b6d9-a7edbebd7ed3">

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices