### PR TITLE
Min staking amount fix

### DIFF
--- a/src/staking-v3/hooks/useDappStaking.ts
+++ b/src/staking-v3/hooks/useDappStaking.ts
@@ -413,7 +413,7 @@ export function useDappStaking() {
       } else if (
         constants.value?.minStakeAmountToken &&
         stake.amount < constants.value.minStakeAmountToken &&
-        stakerInfo.value?.get(stake.address.toLowerCase()) === undefined
+        getStakerInfo(stake.address) === undefined
       ) {
         return [
           false,


### PR DESCRIPTION
**Pull Request Summary**

Users are unable to stake amounts less than `minStakingAmount`on WASM dApps they already already staked to.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
