### PR TITLE
fix: disable sending bridge transactions when Gelato API is down

### DIFF
--- a/src/components/bridge/ethereum/L1.vue
+++ b/src/components/bridge/ethereum/L1.vue
@@ -15,7 +15,7 @@
           :set-right-ui="setRightUi"
           :bridge-amt="String(bridgeAmt)"
           :err-msg="errMsg"
-          :is-disabled-bridge="isDisabledBridge"
+          :is-disabled-bridge="isDisabledBridge || !isGelatoApiConnected"
           :from-bridge-balance="fromBridgeBalance"
           :to-bridge-balance="toBridgeBalance"
           :from-chain-name="fromChainName"
@@ -111,6 +111,7 @@ export default defineComponent({
       l1Network,
       l2Network,
       isActionRequired,
+      isGelatoApiConnected,
       fetchUserHistory,
       handleClaim,
     } = useL1History();
@@ -224,6 +225,7 @@ export default defineComponent({
       isApproved,
       isApproving,
       isApproveMaxAmount,
+      isGelatoApiConnected,
       inputImportTokenHandler,
       cancelHighlight,
       handleSetToken,

--- a/src/hooks/bridge/useL1History.ts
+++ b/src/hooks/bridge/useL1History.ts
@@ -25,7 +25,7 @@ import { useI18n } from 'vue-i18n';
 export const useL1History = () => {
   const { t } = useI18n();
   const store = useStore();
-  const isGelatoApiConnected = ref<boolean>(true);
+  const isGelatoApiConnected = ref<boolean>(false);
 
   const l1Network = computed<string>(() => {
     const networkIdxStore = String(localStorage.getItem(LOCAL_STORAGE.NETWORK_IDX));
@@ -74,6 +74,7 @@ export const useL1History = () => {
   };
 
   const fetchUserHistory = async (): Promise<void> => {
+    if (!currentAccount.value) return;
     try {
       isLoadingHistories.value = true;
       const data = await fetchAccountHistory(currentAccount.value);
@@ -130,17 +131,15 @@ export const useL1History = () => {
       histories.value = formattedResult.sort((a, b) => Number(b.timestamp) - Number(a.timestamp));
     } catch (error) {
       // Memo: disable sending bridge transactions from UI
-      if (isGelatoApiConnected.value) {
-        store.dispatch(
-          'general/showAlertMsg',
-          {
-            msg: t('bridge.gelatoApiError'),
-            alertType: 'error',
-          },
-          { root: true }
-        );
-        isGelatoApiConnected.value = false;
-      }
+      store.dispatch(
+        'general/showAlertMsg',
+        {
+          msg: t('bridge.gelatoApiError'),
+          alertType: 'error',
+        },
+        { root: true }
+      );
+      isGelatoApiConnected.value = false;
       console.error(error);
       isFetchAutomatically.value = false;
     } finally {

--- a/src/hooks/bridge/useL1History.ts
+++ b/src/hooks/bridge/useL1History.ts
@@ -9,6 +9,7 @@ import {
   ZkChainId,
   checkIsL1,
   fetchAccountHistory,
+  fetchIsGelatoApiHealth,
   getChainIdFromNetId,
 } from 'src/modules/zk-evm-bridge';
 import { container } from 'src/v2/common';
@@ -78,6 +79,10 @@ export const useL1History = () => {
     try {
       isLoadingHistories.value = true;
       const data = await fetchAccountHistory(currentAccount.value);
+      const isHealth = await fetchIsGelatoApiHealth();
+      if (!isHealth) {
+        throw Error('The API is currently in maintenance mode.');
+      }
       isGelatoApiConnected.value = true;
 
       const l1Web3 = buildWeb3Instance(EthBridgeChainId[l1Network.value as EthBridgeNetworkName]);

--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -74,7 +74,13 @@ export const useGasPrice = (isFetch = false) => {
   watch(
     [network],
     async () => {
-      if (isFetch && network.value && !gas.value && isEnableSpeedConfiguration.value) {
+      if (
+        isFetch &&
+        network.value &&
+        !gas.value &&
+        isEnableSpeedConfiguration.value &&
+        !isZkEvm.value
+      ) {
         // console.info('gas price', network.value, gas.value);
         await dispatchGasPrice(network.value);
       }

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -986,6 +986,7 @@ export default {
     warning32blocks: 'It could take around 10~20mins or more to finalize',
     warning2steps:
       'Bridging to L1 (Ethereum) involves 2 steps, and it requires users to make a claim on the L1 network (available in Recent History)',
+    gelatoApiError: 'Bridge UI is not available, please try again later',
     tokenInfo: {
       invalidTokenAddress: 'Invalid token address',
       tokenAddress: '{network} token address',

--- a/src/modules/zk-evm-bridge/l1-bridge/utils.ts
+++ b/src/modules/zk-evm-bridge/l1-bridge/utils.ts
@@ -65,6 +65,13 @@ const getApiUrl = (): string => {
   return zkEvmApi[network];
 };
 
+export const fetchIsGelatoApiHealth = async (): Promise<boolean> => {
+  const base = getApiUrl();
+  const url = `${base}/healthz`;
+  const result = await axios.get<{ status: string }>(url);
+  return result && result.data.status === 'SERVING';
+};
+
 export const fetchAccountHistory = async (address: string): Promise<BridgeHistory[]> => {
   const base = getApiUrl();
   const limit = 15;


### PR DESCRIPTION
**Pull Request Summary**

* fix: disable sending bridge transactions when Gelato API is down

**Check list**

- [ ] contains breaking changes
- [x] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**

* fix: disable sending bridge transactions when Gelato API is down

Display the error toast
![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/08b60ab1-39da-409e-962c-c0350685da59)

Disable the button
![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/1867143f-1f0f-4b1a-94b8-82f241642456)
