### PR TITLE
feat: include transaction fee into calculation of ETH balance

### DIFF
--- a/src/components/bridge/ethereum/styles/l1-bridge.scss
+++ b/src/components/bridge/ethereum/styles/l1-bridge.scss
@@ -37,7 +37,6 @@
   padding: 10px 20px;
   border-radius: 6px;
   width: 344px;
-  margin-bottom: 24px;
   border: 1px solid $warning-red;
   background: $box-red;
   text-align: left;

--- a/src/hooks/bridge/useL1Bridge.ts
+++ b/src/hooks/bridge/useL1Bridge.ts
@@ -53,6 +53,7 @@ export const useL1Bridge = () => {
   const bridgeAmt = ref<string | null>(null);
   const toBridgeBalance = ref<number>(0);
   const fromBridgeBalance = ref<number>(0);
+  const isGasPayable = ref<boolean>(false);
   const errMsg = ref<string>('');
   const fromChainName = ref<EthBridgeNetworkName>(l1Network.value);
   const toChainName = ref<EthBridgeNetworkName>(l2Network.value);
@@ -248,6 +249,7 @@ export const useL1Bridge = () => {
     const bridgeAmtRef = Number(bridgeAmt.value);
     const providerChainIdRef = providerChainId.value;
     const selectedTokenRef = selectedToken.value;
+    const isGasPayableRef = isGasPayable.value;
     try {
       if (bridgeAmtRef > fromBridgeBalance.value) {
         errMsg.value = t('warning.insufficientBalance', {
@@ -255,6 +257,8 @@ export const useL1Bridge = () => {
         });
       } else if (providerChainIdRef !== fromChainId.value) {
         errMsg.value = t('warning.selectedInvalidNetworkInWallet');
+      } else if (!isGasPayableRef && bridgeAmtRef > 0) {
+        errMsg.value = t('warning.balanceNotEnough');
       } else {
         errMsg.value = '';
       }
@@ -351,8 +355,25 @@ export const useL1Bridge = () => {
     return hash;
   };
 
+  const setIsGasPayable = async (): Promise<void> => {
+    if (!bridgeAmt.value || !selectedToken.value.address) return;
+    const zkBridgeService = container.get<IZkBridgeService>(Symbols.ZkBridgeService);
+    const destNetworkId = await getNetworkId(toChainName.value);
+
+    const result = await zkBridgeService.dryRunBridgeAsset({
+      amount: bridgeAmt.value,
+      fromChainName: fromChainName.value,
+      toChainName: toChainName.value,
+      senderAddress: currentAccount.value,
+      tokenAddress: selectedToken.value.address,
+      decimal: selectedToken.value.decimal,
+      destNetworkId,
+    });
+    isGasPayable.value = result;
+  };
+
   watch([fromChainId, ethProvider], setProviderChainId, { immediate: true });
-  watch([providerChainId, isLoading, bridgeAmt, selectedToken], setErrorMsg, {
+  watch([providerChainId, isLoading, bridgeAmt, selectedToken, isGasPayable], setErrorMsg, {
     immediate: true,
   });
 
@@ -362,10 +383,18 @@ export const useL1Bridge = () => {
   watch([currentAccount, fromChainName], initZkTokens, { immediate: true });
 
   const debounceDelay = 500;
+  const debounceIsGasPayable = 1000;
   const debouncedSetIsApproved = debounce(setIsApproved, debounceDelay);
+  const debouncedSetIsGasPayable = debounce(setIsGasPayable, debounceIsGasPayable);
+
   watch([selectedToken, fromChainId, currentAccount, bridgeAmt], debouncedSetIsApproved, {
     immediate: true,
   });
+
+  watch([selectedToken, fromChainId, currentAccount, bridgeAmt], debouncedSetIsGasPayable, {
+    immediate: false,
+  });
+
   watch([selectedToken, fromChainId, currentAccount], resetStates);
 
   const autoFetchAllowanceHandler = setInterval(

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -60,7 +60,7 @@ export default {
     blankDestAddress: 'Destination address is blank',
     inputtedInvalidAddress: 'Inputted invalid address',
     selectedInvalidNetworkInWallet: 'Selected invalid network in your wallet',
-    balanceNotEnough: 'You do not have enough ETH in your account to pay for transaction fee',
+    balanceNotEnough: 'You do not have enough ETH in your account to pay for the transaction fee',
     insufficientBridgeAmount: 'Minimum transfer amount is {amount} {token}',
     insufficientOriginChainBalance: 'Minimum balance on {chain} network is {amount} {token}',
     insufficientOriginChainNativeBalance: 'Insufficient native token balance on {chain}',

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -60,6 +60,7 @@ export default {
     blankDestAddress: 'Destination address is blank',
     inputtedInvalidAddress: 'Inputted invalid address',
     selectedInvalidNetworkInWallet: 'Selected invalid network in your wallet',
+    balanceNotEnough: 'You do not have enough ETH in your account to pay for transaction fee',
     insufficientBridgeAmount: 'Minimum transfer amount is {amount} {token}',
     insufficientOriginChainBalance: 'Minimum balance on {chain} network is {amount} {token}',
     insufficientOriginChainNativeBalance: 'Insufficient native token balance on {chain}',

--- a/src/v2/services/IZkBridgeService.ts
+++ b/src/v2/services/IZkBridgeService.ts
@@ -4,6 +4,7 @@ import { BridgeHistory, EthBridgeNetworkName } from 'src/modules/zk-evm-bridge';
 export interface IZkBridgeService {
   approve(param: ParamBridgeAsset): Promise<String>;
   bridgeAsset(param: ParamBridgeAsset): Promise<String>;
+  dryRunBridgeAsset(param: ParamBridgeAsset): Promise<boolean>;
   claimAsset(param: ParamClaim): Promise<String>;
 }
 


### PR DESCRIPTION
**Pull Request Summary**

* feat: include transaction fee into calculation of ETH balance 

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Adds**
* feat: include transaction fee into calculation of ETH balance 

=Before=

Some users seem to think the gas fee is too expensive (which appears to be a bug), but it’s just because users don’t have enough ETH, and that’s why MetaMask fails to calculate the gas fee correctly.

<img src="https://github.com/AstarNetwork/astar-apps/assets/92044428/ec1d24bc-49f4-4fe0-9d25-89286b0a815e" width=400px />

![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/38b5a821-0719-49de-beb6-95a5609e5c8e)

=After=

Calculate the gas fee and display error if user doesn't have ETH to pay the fee, so that MetaMask won't pop up with wrong transaction fee.

![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/77eb5f5e-ce3e-41e2-9b2e-707ec67e21a4)

![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/c13a3b98-7b03-4e4c-a8a3-7e686b85748e)
