### PR TITLE
Fix header banner colour for zkEVM

### DIFF
--- a/src/components/header/YokiBanner.vue
+++ b/src/components/header/YokiBanner.vue
@@ -67,7 +67,7 @@ export default defineComponent({
 
   // zkEVM
   &.banner--3 {
-    background: linear-gradient(90deg, #703ac2 25%, #226dff 100%);
+    background: linear-gradient(90deg, #0047ff 0%, #00d4ff 100%);
   }
 }
 


### PR DESCRIPTION
**Pull Request Summary**

Fix the header banner colour for zkEVM

<img width="1448" alt="Screenshot 2024-03-11 at 11 46 30 AM" src="https://github.com/AstarNetwork/astar-apps/assets/33358068/37af74ce-7965-4012-9917-71dbcce1aa75">

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Adds**

- (ex: Add feature A)

**Fixes**

- (ex: Fix validation function)

**Changes**

- (ex: Change document B)

**To-dos**

> \*Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)
