### PR TITLE
feat: display the amount of bonus rewards for Astar and Shiden

### DIFF
--- a/src/staking-v3/components/my-staking/MyStaking.vue
+++ b/src/staking-v3/components/my-staking/MyStaking.vue
@@ -125,7 +125,6 @@
           :caption="$t('stakingV3.bonus')"
           :amount="bonus"
           :eras="bonusRewardEras"
-          :is-text-bonus-eligible="isMainnet"
           :is-tool-tip="!!bonus"
           :text-tool-tip="$t('stakingV3.bonusTip')"
         />

--- a/src/staking-v3/components/my-staking/MyStakingCard.vue
+++ b/src/staking-v3/components/my-staking/MyStakingCard.vue
@@ -28,12 +28,7 @@
         {{ $t(`stakingV3.${eras > 1 ? 'days' : 'day'}`, { day: eras }) }}
       </span>
     </div>
-    <div v-if="isTextBonusEligible && amount.toString() > '0'" class="card--balance">
-      <div class="card--amount">
-        <span>{{ $t('stakingV3.bonusEligible') }}</span>
-      </div>
-    </div>
-    <div v-else class="card--balance">
+    <div class="card--balance">
       <div class="card--amount">
         {{ $n(truncate(ethers.utils.formatEther(amount.toString()) ?? '0', 2)) }}
       </div>
@@ -62,11 +57,6 @@ export default defineComponent({
       type: Number,
       required: false,
       default: 0,
-    },
-    isTextBonusEligible: {
-      type: Boolean,
-      required: false,
-      default: false,
     },
     isToolTip: {
       type: Boolean,


### PR DESCRIPTION
**Pull Request Summary**

* feat: display the amount of bonus rewards for Astar and Shiden

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Adds**

![image](https://github.com/AstarNetwork/astar-apps/assets/92044428/a561c660-a1f7-4bb4-bd18-96417bd91376)
