### PR TITLE
Put back Yoki Origins banner

### DIFF
--- a/src/layouts/DashboardLayout.vue
+++ b/src/layouts/DashboardLayout.vue
@@ -5,8 +5,8 @@
     </template>
     <div class="wrapper--dashboard-layout__inner">
       <portal-header />
-      <under-maintenance-banner />
-      <!-- <yoki-banner :network="currentNetworkIdx" /> -->
+      <!-- <under-maintenance-banner /> -->
+      <yoki-banner :network="currentNetworkIdx" />
       <main id="assets-top" class="wrapper--main">
         <div class="wrapper--components">
           <div class="page-bg" :style="{ backgroundImage: `url(${bg})` }" />
@@ -27,12 +27,13 @@ import { useQuasar } from 'quasar';
 import { LOCAL_STORAGE } from 'src/config/localStorage';
 import { useStore } from 'src/store';
 import UnderMaintenanceBanner from 'src/components/header/UnderMaintenanceBanner.vue';
+import YokiBanner from 'src/components/header/YokiBanner.vue';
 
 export default defineComponent({
   components: {
     PortalHeader,
     SidebarDesktop,
-    UnderMaintenanceBanner,
+    YokiBanner,
   },
   setup() {
     const store = useStore();


### PR DESCRIPTION
**Pull Request Summary**

Removed zk maintenance banner and put back Yoki banner

<img width="800" alt="image" src="https://github.com/AstarNetwork/astar-apps/assets/8452361/4001bd24-1e62-4e80-b992-774675b01ae5">


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**
