### PR TITLE
Tokens to be burned calculation fix

### DIFF
--- a/src/staking-v3/hooks/useDataCalculations.ts
+++ b/src/staking-v3/hooks/useDataCalculations.ts
@@ -61,8 +61,7 @@ export function useDataCalculations() {
       const dappsInTier = leaderBoards.value.get(i + 1)?.length ?? 0;
       const tokensForTier =
         reward *
-        (BigInt(slotsPerTier) - BigInt(dappsInTier)) *
-        BigInt(eraLengths.value.standardErasPerBuildAndEarnPeriod);
+        BigInt((slotsPerTier - dappsInTier) * eraLengths.value.standardErasPerBuildAndEarnPeriod);
       return acc + tokensForTier;
     }, BigInt(0));
 

--- a/src/staking-v3/hooks/useDataCalculations.ts
+++ b/src/staking-v3/hooks/useDataCalculations.ts
@@ -60,9 +60,9 @@ export function useDataCalculations() {
       const slotsPerTier = tiersConfiguration.value.slotsPerTier[i];
       const dappsInTier = leaderBoards.value.get(i + 1)?.length ?? 0;
       const tokensForTier =
-        ((reward * (BigInt(slotsPerTier) - BigInt(dappsInTier))) / BigInt(slotsPerTier)) *
+        reward *
+        (BigInt(slotsPerTier) - BigInt(dappsInTier)) *
         BigInt(eraLengths.value.standardErasPerBuildAndEarnPeriod);
-
       return acc + tokensForTier;
     }, BigInt(0));
 


### PR DESCRIPTION
**Pull Request Summary**

Fixed bug in tokens to be burned calculation. The calculation is still not 100% correct, because of an assumption that dApp tier allocation will be the same through all build and earn sub period eras. Fixing this requires a bit more time and it will be done next week.

Before
![image](https://github.com/AstarNetwork/astar-apps/assets/8452361/fdc2993a-ca1b-4c2e-92a9-92d6fe591e8d)

After
![image](https://github.com/AstarNetwork/astar-apps/assets/8452361/77c7c98d-ff48-4eff-92e5-754edd456dc2)



**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
