### PR TITLE
add native bridge deposit warning banner

### DIFF
--- a/src/components/bridge/ethereum/L1Bridge.vue
+++ b/src/components/bridge/ethereum/L1Bridge.vue
@@ -134,7 +134,7 @@
         <span class="color--white"> {{ $t(errMsg) }}</span>
       </div>
 
-      <div v-if="isWarningHighTraffic" class="row--box-error">
+      <div v-if="isZkEvmDeposit" class="row--box-error">
         <span class="color--white">
           {{ $t('bridge.warningHighTraffic') }}
           <!-- <a class="color--white text-underline" @click="setHighTrafficModalOpen(true)">
@@ -153,14 +153,14 @@
       <div class="row--buttons">
         <astar-button
           class="button--confirm"
-          :disabled="isApproved || isDisabledBridge || isHandling || isLoading"
+          :disabled="isApproved || isDisabledBridge || isHandling || isLoading || isZkEvmDeposit"
           @click="approve"
         >
           {{ $t('approve') }}
         </astar-button>
         <astar-button
           class="button--confirm"
-          :disabled="!isApproved || isDisabledBridge || isHandling || isLoading"
+          :disabled="!isApproved || isDisabledBridge || isHandling || isLoading || isZkEvmDeposit"
           @click="bridge"
         >
           {{ $t('bridge.bridge') }}
@@ -278,7 +278,7 @@ export default defineComponent({
     const isLoading = computed<boolean>(() => store.getters['general/isLoading']);
     const isEnabledWithdrawal = computed<boolean>(() => true);
     const isHighTrafficModalOpen = ref<boolean>(false);
-    const isWarningHighTraffic = computed<boolean>(
+    const isZkEvmDeposit = computed<boolean>(
       () => props.toChainName === EthBridgeNetworkName.AstarZk
     );
 
@@ -334,7 +334,7 @@ export default defineComponent({
       approve,
       isHighTrafficModalOpen,
       setHighTrafficModalOpen,
-      isWarningHighTraffic,
+      isZkEvmDeposit,
     };
   },
 });

--- a/src/components/bridge/ethereum/L1Bridge.vue
+++ b/src/components/bridge/ethereum/L1Bridge.vue
@@ -137,9 +137,9 @@
       <div v-if="isWarningHighTraffic" class="row--box-error">
         <span class="color--white">
           {{ $t('bridge.warningHighTraffic') }}
-          <a class="color--white text-underline" @click="setHighTrafficModalOpen(true)">
+          <!-- <a class="color--white text-underline" @click="setHighTrafficModalOpen(true)">
             {{ $t('bridge.warningHighTrafficMore') }}
-          </a>
+          </a> -->
         </span>
       </div>
 
@@ -279,7 +279,7 @@ export default defineComponent({
     const isEnabledWithdrawal = computed<boolean>(() => true);
     const isHighTrafficModalOpen = ref<boolean>(false);
     const isWarningHighTraffic = computed<boolean>(
-      () => props.fromChainName === EthBridgeNetworkName.AstarZk
+      () => props.toChainName === EthBridgeNetworkName.AstarZk
     );
 
     const setHighTrafficModalOpen = (value: boolean): void => {

--- a/src/components/bridge/ethereum/L1Bridge.vue
+++ b/src/components/bridge/ethereum/L1Bridge.vue
@@ -136,9 +136,9 @@
 
       <div v-if="isZkEvmDeposit" class="row--box-error">
         <span class="color--white">
-          {{ $t('bridge.warningHighTraffic') }}
+          {{ $t('bridge.warningMessage') }}
           <!-- <a class="color--white text-underline" @click="setHighTrafficModalOpen(true)">
-            {{ $t('bridge.warningHighTrafficMore') }}
+            {{ $t('bridge.warningMore') }}
           </a> -->
         </span>
       </div>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1039,7 +1039,7 @@ export default {
       'Bridging to L1 (Ethereum) involves 2 steps, and it requires users to make a claim on the L1 network (available in Recent History)',
     gelatoApiError: 'Bridge UI is not available, please try again later',
     warningHighTraffic:
-      'High bridge traffic may delay withdrawal transactions up to 20 hours. We appreciate your patience.',
+      'Deposits from Ethereum to Astar zkEVM are taking longer than usual and up to several days. We are currently investigating this issue. Please take this into account before using the native bridge.',
     warningHighTrafficMore: '(read more)',
     modals: {
       highTraffic: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1038,8 +1038,8 @@ export default {
     warning2steps:
       'Bridging to L1 (Ethereum) involves 2 steps, and it requires users to make a claim on the L1 network (available in Recent History)',
     gelatoApiError: 'Bridge UI is not available, please try again later',
-    warningHighTraffic: 'Deposit is currently being disabled due to maintenance.',
-    warningHighTrafficMore: '(read more)',
+    warningMessage: 'Deposit is currently being disabled due to maintenance.',
+    warningMore: '(read more)',
     modals: {
       highTraffic: {
         text1:

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1038,8 +1038,7 @@ export default {
     warning2steps:
       'Bridging to L1 (Ethereum) involves 2 steps, and it requires users to make a claim on the L1 network (available in Recent History)',
     gelatoApiError: 'Bridge UI is not available, please try again later',
-    warningHighTraffic:
-      'Deposits from Ethereum to Astar zkEVM are taking longer than usual and up to several days. We are currently investigating this issue. Please take this into account before using the native bridge.',
+    warningHighTraffic: 'Deposit is currently being disabled due to maintenance.',
     warningHighTrafficMore: '(read more)',
     modals: {
       highTraffic: {


### PR DESCRIPTION
**Pull Request Summary**

> Enable deposit warning banner on portal

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**

- Enable deposit warning banner on portal

I re-used the codes we was added for withdrawal banner, there's something need to changed (like variable naming). but I think it's not a big issue atm.