### PR TITLE
update withdrawal warning 20h -> 5h

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1039,7 +1039,7 @@ export default {
       'Bridging to L1 (Ethereum) involves 2 steps, and it requires users to make a claim on the L1 network (available in Recent History)',
     gelatoApiError: 'Bridge UI is not available, please try again later',
     warningHighTraffic:
-      'High bridge traffic may delay withdrawal transactions up to 20 hours. We appreciate your patience.',
+      'High bridge traffic may delay withdrawal transactions up to 5 hours. We appreciate your patience.',
     warningHighTrafficMore: '(read more)',
     modals: {
       highTraffic: {


### PR DESCRIPTION
**Pull Request Summary**

> Update withdrawal warning texts on bridge

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [x] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**

- update `bridge.warningHighTraffic` text
