### PR TITLE
Hardcode inflation period start blocks

### DIFF
--- a/src/components/common/styles/chart-panel.scss
+++ b/src/components/common/styles/chart-panel.scss
@@ -28,7 +28,6 @@
   border-radius: 6px;
   @media (min-width: $xxl) {
     height: 433px;
-    width: 560px;
   }
 }
 

--- a/src/components/dashboard/Inflation.vue
+++ b/src/components/dashboard/Inflation.vue
@@ -85,7 +85,9 @@ export default defineComponent({
     const pieSectors = ref<Sector[]>([]);
     const isDarkTheme = computed<boolean>(() => store.getters['general/theme'] === 'DARK');
 
-    const numberFromPercentage = (value?: number): number | string => (value ? value * 100 : '--');
+    const numberFromPercentage = (value?: number): number | string =>
+      value !== undefined ? value * 100 : '--';
+
     const adjustableStakersPercentage = computed<number>(() =>
       Number(
         (

--- a/src/data/dapp_promotions.json
+++ b/src/data/dapp_promotions.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "Archisinal",
+    "shortDescription": "Pioneering Real-World-Assets in the built environment",
+    "link": "https://www.archisinal.io/",
+    "img": "images/dapp_promotions/Archisinal.png"
+  },
+  {
     "name": "DeStore",
     "shortDescription": "Web3 Shopify Powered by Astar",
     "link": "https://twitter.com/DeStore_Network",
@@ -46,11 +52,5 @@
     "shortDescription": "#1 Cross-chain Social Fitness App on iOS & Android, Apple Watch",
     "link": "https://app.moonfit.xyz/astar-reward",
     "img": "images/dapp_promotions/moonfit.png"
-  },
-  {
-    "name": "Archisinal",
-    "shortDescription": "Pioneering Real-World-Assets in the built environment",
-    "link": "https://www.archisinal.io/",
-    "img": "images/dapp_promotions/Archisinal.png"
   }
 ]

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -695,6 +695,7 @@ export default {
       currentInflationRate: 'Current inflation rate',
       maximumInflation: 'Maximum inflation ({rate}%)',
       realizedInflation: 'Realized inflation',
+      wrongNetwork: 'Period 1 start block is not defined for the current network {network}.',
     },
   },
   chart: {


### PR DESCRIPTION
**Pull Request Summary**

Initially I used Blockscout API to determine starting block of inflation period 1. Since Subscan started to give us "too many requests" error I decided to hardcode block number for each network since this will never change. I should do that intially.

Also reordered latest promotion card to be visible on dApp staking page

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
