### PR TITLE
fix recent history link for zkevm

### DIFF
--- a/src/components/assets/transfer/Information.vue
+++ b/src/components/assets/transfer/Information.vue
@@ -100,7 +100,10 @@ import { getXvmAssetsTransferHistories } from 'src/modules/information/recent-hi
 import { useStore } from 'src/store';
 import { computed, defineComponent, PropType, ref, watchEffect, onUnmounted } from 'vue';
 import { RecentLzHistory } from '../../../modules/information/index';
-import { getLzTxHistories } from '../../../modules/information/recent-history/transfer/index';
+import {
+  getLzTxHistories,
+  getZkEVMTxHistories,
+} from '../../../modules/information/recent-history/transfer/index';
 import { LOCAL_STORAGE } from '../../../config/localStorage';
 import { endpointKey, providerEndpoints } from '../../../config/chainEndpoints';
 
@@ -156,6 +159,11 @@ export default defineComponent({
       } else if (props.transferType === HistoryTxType.LZ_BRIDGE) {
         lztTxHistories.value = await getLzTxHistories({
           address: currentAccount.value,
+          network,
+        });
+      } else if (props.transferType === HistoryTxType.ZK_ETHEREUM_BRIDGE) {
+        txHistories.value = await getZkEVMTxHistories({
+          address: isH160.value ? currentAccount.value : senderSs58Account.value,
           network,
         });
       } else {

--- a/src/components/assets/transfer/Information.vue
+++ b/src/components/assets/transfer/Information.vue
@@ -100,10 +100,7 @@ import { getXvmAssetsTransferHistories } from 'src/modules/information/recent-hi
 import { useStore } from 'src/store';
 import { computed, defineComponent, PropType, ref, watchEffect, onUnmounted } from 'vue';
 import { RecentLzHistory } from '../../../modules/information/index';
-import {
-  getLzTxHistories,
-  getZkEVMTxHistories,
-} from '../../../modules/information/recent-history/transfer/index';
+import { getLzTxHistories } from '../../../modules/information/recent-history/transfer/index';
 import { LOCAL_STORAGE } from '../../../config/localStorage';
 import { endpointKey, providerEndpoints } from '../../../config/chainEndpoints';
 
@@ -159,11 +156,6 @@ export default defineComponent({
       } else if (props.transferType === HistoryTxType.LZ_BRIDGE) {
         lztTxHistories.value = await getLzTxHistories({
           address: currentAccount.value,
-          network,
-        });
-      } else if (props.transferType === HistoryTxType.ZK_ETHEREUM_BRIDGE) {
-        txHistories.value = await getZkEVMTxHistories({
-          address: isH160.value ? currentAccount.value : senderSs58Account.value,
           network,
         });
       } else {

--- a/src/modules/information/recent-history/transfer/index.ts
+++ b/src/modules/information/recent-history/transfer/index.ts
@@ -201,16 +201,14 @@ export const getZkEVMTxHistories = async ({
   network: string;
 }): Promise<RecentHistory[]> => {
   const txs: TxHistory[] = [];
-  const histories = [XVM_TX_HISTORIES, XCM_TX_HISTORIES, TX_HISTORIES];
+  const storageKey = TX_HISTORIES;
 
-  histories.forEach((storageKey) => {
-    const transactions = getAccountHistories({
-      storageKey,
-      address,
-      network,
-    });
-    transactions.forEach((it) => txs.push(it));
+  const transactions = getAccountHistories({
+    storageKey,
+    address,
+    network,
   });
+  transactions.forEach((it) => txs.push(it));
 
   const formattedTxs = txs.sort((a, b) => b.timestamp - a.timestamp).slice(0, NumberOfHistories);
 

--- a/src/modules/information/recent-history/transfer/index.ts
+++ b/src/modules/information/recent-history/transfer/index.ts
@@ -218,9 +218,7 @@ export const getZkEVMTxHistories = async ({
     formattedTxs.map(async (it) => {
       const { hash } = it;
       try {
-        console.log(it);
         const tx = await fetchTransferDetails({ hash, network });
-        console.log(tx);
         return castZkEVMTransferHistory({ tx, hash });
       } catch (error) {
         console.error(error);


### PR DESCRIPTION
**Pull Request Summary**

> in the transaction page, link of recent history using Astar zkEVM is linked to subscan, I separate the logic of aggregate transaction history

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Adds**

- castZkEVMTransferHistory function in `modules/information/recent-history/index.ts`
- getZkEVMTxHistories function in `modules/information/recent-history/index.ts`

**Fixes**

- separate aggregate tx histories logic for zkEVM in setTxHistories function at `components/assets/transfer/Information.vue`
