### PR TITLE
Inflation chart

### DIFF
--- a/src/hooks/useInflation.ts
+++ b/src/hooks/useInflation.ts
@@ -78,7 +78,9 @@ export function useInflation(): UseInflation {
       const balancesRepository = container.get<IBalancesRepository>(Symbols.BalancesRepository);
       const initialTotalIssuance =
         (await balancesRepository.getTotalIssuance(period1StartBlock - 1)) -
-        BigInt('350000000000000000000000000'); // Quick fox for token burning event. TODO make a proper solution
+        (networkNameSubstrate.value.toLowerCase() === 'astar'
+          ? BigInt('350000000000000000000000000')
+          : BigInt(0)); // Quick fox for token burning event. TODO make a proper solution
       const realizedTotalIssuance = await balancesRepository.getTotalIssuance();
 
       const {

--- a/src/hooks/useInflation.ts
+++ b/src/hooks/useInflation.ts
@@ -76,7 +76,9 @@ export function useInflation(): UseInflation {
       }
 
       const balancesRepository = container.get<IBalancesRepository>(Symbols.BalancesRepository);
-      const initialTotalIssuance = await balancesRepository.getTotalIssuance(period1StartBlock - 1);
+      const initialTotalIssuance =
+        (await balancesRepository.getTotalIssuance(period1StartBlock - 1)) -
+        BigInt('350000000000000000000000000'); // Quick fox for token burning event. TODO make a proper solution
       const realizedTotalIssuance = await balancesRepository.getTotalIssuance();
 
       const {


### PR DESCRIPTION
**Pull Request Summary**

Token burning on Astar happened today and realized inflation chart went wrong. This happened because actual token issuance after burning is lower than at the beginning of staking period 1.
![image](https://github.com/AstarNetwork/astar-apps/assets/8452361/39ebba80-cfc4-44e9-b99d-a3d14467f0b8)

As a quick fix I deduced burned amount from token issuance at the beginning of period 1.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
