### PR TITLE
Fix use price

### DIFF
--- a/src/hooks/usePrice.ts
+++ b/src/hooks/usePrice.ts
@@ -10,6 +10,7 @@ export function usePrice() {
     const chainInfo = store.getters['general/chainInfo'];
     return chainInfo ? chainInfo.tokenSymbol : '';
   });
+  const isH160 = computed<boolean>(() => store.getters['general/isH160Formatted']);
 
   const { isMainnet, isAstarZkEvm } = useNetworkInfo();
   const { currentAccount } = useAccount();
@@ -31,7 +32,7 @@ export function usePrice() {
         console.error(error.message);
       }
     },
-    { immediate: true }
+    { immediate: isH160.value }
   );
 
   return {


### PR DESCRIPTION
**Pull Request Summary**

> To avoid big number error, enable immediate only for H160 address in usePrice hooks

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Changes**

- only enable immediate for h160 address

