### PR TITLE
User burn events in inflation charts

### DIFF
--- a/src/components/dashboard/Inflation.vue
+++ b/src/components/dashboard/Inflation.vue
@@ -88,12 +88,12 @@ export default defineComponent({
     const numberFromPercentage = (value?: number): number | string =>
       value !== undefined ? value * 100 : '--';
 
-    const adjustableStakersPercentage = computed<number>(() =>
-      Number(
-        (
-          realizedAdjustableStakersPart.value / inflationParameters.value.adjustableStakersPart
-        ).toFixed(3)
-      )
+    const adjustableStakersPercentage = computed<number>(
+      () =>
+        Math.round(
+          (realizedAdjustableStakersPart.value / inflationParameters.value.adjustableStakersPart) *
+            100
+        ) / 100
     );
 
     watch(

--- a/src/components/dashboard/InflationRateChart.vue
+++ b/src/components/dashboard/InflationRateChart.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref, watch } from 'vue';
+import { defineComponent, computed, ref, watch, onMounted } from 'vue';
 import { Chart } from 'highcharts-vue';
 import { useStore } from 'src/store';
 import { titleFormatter, seriesFormatter } from 'src/modules/token-api';
@@ -43,11 +43,16 @@ export default defineComponent({
     const getTextColor = (): string => (isDarkTheme.value ? '#5F656F' : '#B1B7C1');
     const hasData = ref<boolean>(false);
     const { t } = useI18n();
-    const { maximumInflationData, realizedInflationData, estimatedInflation, inflationParameters } =
-      useInflation();
+    const {
+      maximumInflationData,
+      realizedInflationData,
+      estimatedInflation,
+      inflationParameters,
+      estimateRealizedInflation,
+    } = useInflation();
 
     const maximumInflationRate = computed<string>(() =>
-      (inflationParameters.value.maxInflationRate * 100).toFixed(1)
+      ((inflationParameters.value?.maxInflationRate ?? 0) * 100).toFixed(1)
     );
 
     Highcharts.setOptions({
@@ -152,6 +157,10 @@ export default defineComponent({
       } else {
         hasData.value = false;
       }
+    });
+
+    onMounted(() => {
+      estimateRealizedInflation();
     });
 
     return {

--- a/src/hooks/useInflation.ts
+++ b/src/hooks/useInflation.ts
@@ -2,13 +2,23 @@ import { computed, watch, ref, Ref, ComputedRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useStore } from 'src/store';
 import { container } from 'src/v2/common';
-import { IBalancesRepository, IInflationRepository } from 'src/v2/repositories';
+import {
+  IBalancesRepository,
+  IInflationRepository,
+  ISubscanRepository,
+  SubscanEventResponse,
+} from 'src/v2/repositories';
 import { Symbols } from 'src/v2/symbols';
 import { InflationConfiguration } from 'src/v2/models';
 import { InflationParam, useDappStaking } from 'src/staking-v3';
 import { ethers } from 'ethers';
 import { useNetworkInfo } from './useNetworkInfo';
 import { PERIOD1_START_BLOCKS } from 'src/consts';
+
+type BurnData = {
+  block: number;
+  amount: bigint;
+};
 
 type UseInflation = {
   activeInflationConfiguration: ComputedRef<InflationConfiguration>;
@@ -20,6 +30,7 @@ type UseInflation = {
   fetchActiveConfigurationToStore: () => Promise<void>;
   fetchInflationParamsToStore: () => Promise<void>;
   getInflationParameters: () => Promise<InflationParam>;
+  estimateRealizedInflation: () => Promise<void>;
 };
 
 export function useInflation(): UseInflation {
@@ -57,12 +68,36 @@ export function useInflation(): UseInflation {
     return await inflationRepository.getInflationParams();
   };
 
+  const getBurnEvents = async (): Promise<BurnData[]> => {
+    // Ignore burn events with less than 1M ASTAR. They are not impacting charts a lot small burn amounts
+    // could be a spam.
+    const minBurn = BigInt('1000000000000000000000000');
+    // const subscanRepository = container.get<ISubscanRepository>(Symbols.SubscanRepository);
+    // const result = await subscanRepository.getEvents(
+    //   networkNameSubstrate.value.toLocaleLowerCase(),
+    //   'balances',
+    //   'Burned'
+    // );
+
+    // Temp data for astar
+    return [
+      {
+        block: 6531556,
+        amount: BigInt('2000000000000000000'),
+      },
+      {
+        block: 6557078,
+        amount: BigInt('350000000000000000000000000'),
+      },
+    ].filter((item) => item.amount >= minBurn);
+  };
+
   /**
    * Estimates the realized inflation rate percentage based on the actual total issuance at the beginning
    * and estimated total issuance at the end of the current cycle.
    * According to the https://github.com/AstarNetwork/astar-apps/issues/1259
    */
-  const estimateRealizedInflation = async (): Promise<number | undefined> => {
+  const estimateRealizedInflation = async (): Promise<void> => {
     let inflation: number | undefined;
 
     try {
@@ -76,12 +111,17 @@ export function useInflation(): UseInflation {
       }
 
       const balancesRepository = container.get<IBalancesRepository>(Symbols.BalancesRepository);
-      const initialTotalIssuance =
-        (await balancesRepository.getTotalIssuance(period1StartBlock - 1)) -
-        (networkNameSubstrate.value.toLowerCase() === 'astar'
-          ? BigInt('350000000000000000000000000')
-          : BigInt(0)); // Quick fox for token burning event. TODO make a proper solution
+      const initialTotalIssuance = await balancesRepository.getTotalIssuance(period1StartBlock - 1); // -
       const realizedTotalIssuance = await balancesRepository.getTotalIssuance();
+
+      const burnEvents = await getBurnEvents();
+      // Add first and last block so charts can be easily drawn.
+      burnEvents.splice(0, 0, { block: period1StartBlock, amount: BigInt(0) });
+      burnEvents.push({ block: currentBlock.value, amount: BigInt(0) });
+
+      const totalBurn = burnEvents.reduce((acc, item) => acc + item.amount, BigInt(0));
+      // Used to calculate inflation rate.
+      const initialTotalIssuanceWithoutBurn = initialTotalIssuance - totalBurn;
 
       const {
         periodsPerCycle,
@@ -95,13 +135,14 @@ export function useInflation(): UseInflation {
         (standardErasPerBuildAndEarnPeriod + standardErasPerVotingPeriod);
       const blockDifference = BigInt(currentBlock.value - period1StartBlock);
       const slope =
-        BigInt((realizedTotalIssuance - initialTotalIssuance).toString()) / blockDifference;
+        BigInt((realizedTotalIssuance - initialTotalIssuanceWithoutBurn).toString()) /
+        blockDifference;
 
       // Estimate total issuance at the end of the current cycle.
       const endOfCycleBlock = period1StartBlock + cycleLengthInBlocks;
       const endOfCycleTotalIssuance = Number(
         ethers.utils.formatEther(
-          slope * BigInt(endOfCycleBlock - period1StartBlock) + initialTotalIssuance
+          slope * BigInt(endOfCycleBlock - period1StartBlock) + initialTotalIssuanceWithoutBurn
         )
       );
 
@@ -109,7 +150,7 @@ export function useInflation(): UseInflation {
       inflation =
         (100 *
           (endOfCycleTotalIssuance -
-            Number(ethers.utils.formatEther(initialTotalIssuance.toString())))) /
+            Number(ethers.utils.formatEther(initialTotalIssuanceWithoutBurn.toString())))) /
         endOfCycleTotalIssuance;
 
       // Calculate maximum and realized inflation for each era in the cycle.
@@ -118,8 +159,9 @@ export function useInflation(): UseInflation {
         endOfCycleBlock,
         initialTotalIssuance,
         cycleLengthInBlocks,
-        inflationParameters.value.maxInflationRate,
-        eraLengths.value.standardEraLength
+        inflationParameters.value?.maxInflationRate ?? 0,
+        eraLengths.value.standardEraLength,
+        burnEvents
       );
 
       calculateRealizedInflationData(
@@ -127,7 +169,8 @@ export function useInflation(): UseInflation {
         currentBlock.value,
         slope,
         eraLengths.value.standardEraLength,
-        initialTotalIssuance
+        initialTotalIssuance,
+        burnEvents
       );
 
       calculateAdjustableStakerRewards(
@@ -140,7 +183,7 @@ export function useInflation(): UseInflation {
       console.error('Error calculating realized inflation', error);
     }
 
-    return inflation;
+    estimatedInflation.value = inflation;
   };
 
   const calculateMaximumInflationData = (
@@ -149,7 +192,8 @@ export function useInflation(): UseInflation {
     firstBlockIssuance: bigint,
     cycleLengthInBlocks: number,
     maxInflation: number,
-    eraLength: number
+    eraLength: number,
+    burnEvents: BurnData[]
   ): void => {
     const result: [number, number][] = [];
     const inflation = BigInt(Math.floor(maxInflation * 100)) * BigInt('10000000000000000');
@@ -157,14 +201,17 @@ export function useInflation(): UseInflation {
     const cycleLength = BigInt(cycleLengthInBlocks);
 
     // One sample per era.
-    for (let i = firstBlock; i <= lastBlock; i += eraLength) {
-      const inflation =
-        (cycleProgression * BigInt(i - firstBlock)) / cycleLength + firstBlockIssuance;
+    for (let j = 0; j < burnEvents.length - 1; j++) {
+      for (let i = burnEvents[j].block; i <= burnEvents[j + 1].block + eraLength; i += eraLength) {
+        const inflation =
+          (cycleProgression * BigInt(i - firstBlock)) / cycleLength +
+          firstBlockIssuance -
+          burnEvents[j].amount;
 
-      result.push([i, Number(ethers.utils.formatEther(inflation.toString()))]);
+        result.push([i, Number(ethers.utils.formatEther(inflation.toString()))]);
+      }
     }
 
-    // console.log((result[result.length - 1][1] - result[0][1]) / result[result.length - 1][1]);
     maximumInflationData.value = result;
   };
 
@@ -173,16 +220,21 @@ export function useInflation(): UseInflation {
     lastBlock: number,
     slope: bigint,
     eraLength: number,
-    firstBlockIssuance: bigint
+    firstBlockIssuance: bigint,
+    burnEvents: BurnData[]
   ): void => {
     const result: [number, number][] = [];
 
-    for (let i = firstBlock; i <= lastBlock; i += eraLength) {
-      const currentBlockIssuance = Number(
-        ethers.utils.formatEther(slope * BigInt(i - firstBlock) + firstBlockIssuance)
-      );
+    for (let j = 0; j < burnEvents.length - 1; j++) {
+      for (let i = burnEvents[j].block; i <= burnEvents[j + 1].block + eraLength; i += eraLength) {
+        const currentBlockIssuance = Number(
+          ethers.utils.formatEther(
+            slope * BigInt(i - firstBlock) + firstBlockIssuance - burnEvents[j].amount
+          )
+        );
 
-      result.push([i, currentBlockIssuance]);
+        result.push([i, currentBlockIssuance]);
+      }
     }
 
     realizedInflationData.value = result;
@@ -203,18 +255,8 @@ export function useInflation(): UseInflation {
     realizedAdjustableStakersPart.value = Number(result.toFixed(3));
   };
 
-  watch(
-    [activeInflationConfiguration, inflationParameters],
-    async () => {
-      if (activeInflationConfiguration.value && inflationParameters.value) {
-        estimatedInflation.value = await estimateRealizedInflation();
-      }
-    },
-    { immediate: true }
-  );
-
   return {
-    activeInflationConfiguration,
+    activeInflationConfiguration: activeInflationConfiguration,
     estimatedInflation,
     inflationParameters,
     maximumInflationData,
@@ -223,5 +265,6 @@ export function useInflation(): UseInflation {
     fetchActiveConfigurationToStore,
     fetchInflationParamsToStore,
     getInflationParameters,
+    estimateRealizedInflation,
   };
 }

--- a/src/v2/repositories/ITokenApiRepository.ts
+++ b/src/v2/repositories/ITokenApiRepository.ts
@@ -4,6 +4,13 @@ export type PeriodData = {
   stakeAmount: bigint;
 };
 
+export type BurnEvent = {
+  blockNumber: number;
+  timestamp: number;
+  amount: bigint;
+  user: string;
+};
+
 /**
  * Definition of repository for access token price.
  */
@@ -20,4 +27,10 @@ export interface ITokenApiRepository {
    * @param period Period number.
    */
   getStakingPeriodStatistics(network: string, period: number): Promise<PeriodData[]>;
+
+  /**
+   * Gets burn events for the given network.
+   * @param network Network name.
+   */
+  getBurnEvents(network: string): Promise<BurnEvent[]>;
 }

--- a/src/v2/repositories/implementations/SubscanRepository.ts
+++ b/src/v2/repositories/implementations/SubscanRepository.ts
@@ -20,7 +20,7 @@ export class SubscanRepository implements ISubscanRepository {
 
     const payload = {
       module,
-      event: eventName,
+      event_id: eventName,
       page,
       row: pageSize,
     };

--- a/src/v2/repositories/implementations/TokenApiRepository.ts
+++ b/src/v2/repositories/implementations/TokenApiRepository.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { injectable } from 'inversify';
-import { ITokenApiRepository, PeriodData } from '../ITokenApiRepository';
+import { BurnEvent, ITokenApiRepository, PeriodData } from '../ITokenApiRepository';
 
 @injectable()
 export class TokenApiRepository implements ITokenApiRepository {
@@ -25,6 +25,23 @@ export class TokenApiRepository implements ITokenApiRepository {
           dappAddress: data.dappAddress,
           stakeAmount: BigInt(data.stakeAmount),
           rewardAmount: BigInt(data.rewardAmount),
+        };
+      });
+    } catch (error) {
+      return [];
+    }
+  }
+
+  public async getBurnEvents(network: string): Promise<BurnEvent[]> {
+    try {
+      const url = `${TokenApiRepository.BaseUrl}/v1/${network}/burn/events`;
+      const response = await axios.get<BurnEvent[]>(url);
+      return response.data.map((data) => {
+        return {
+          blockNumber: data.blockNumber,
+          timestamp: data.timestamp,
+          amount: BigInt(data.amount),
+          user: data.user,
         };
       });
     } catch (error) {


### PR DESCRIPTION
**Pull Request Summary**

Take burn events into account when calulating and drawing inflation charts

<img width="502" alt="image" src="https://github.com/user-attachments/assets/2fd0c7c0-13de-4b05-9f0a-a7bf278ae5d9">

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Adds**

- (ex: Add feature A)

**Fixes**

- (ex: Fix validation function)

**Changes**

- (ex: Change document B)

**To-dos**

> \*Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)
