### PR TITLE
Centralized configuration - part 1

### DIFF
--- a/src/components/assets/Erc20Currency.vue
+++ b/src/components/assets/Erc20Currency.vue
@@ -53,7 +53,10 @@
           </router-link>
 
           <div v-if="token.isWrappedToken && !token.isXC20">
-            <a :href="token.bridgeUrl ?? undefined" target="_blank" rel="noopener noreferrer">
+            <custom-router-link
+              :to="token.bridgeUrl ?? ''"
+              :is-disabled="!token.bridgeUrl || !isBridgeEnabled(token.bridgeUrl)"
+            >
               <button class="btn btn--icon">
                 <astar-icon-bridge class="icon--bridge" />
               </button>
@@ -61,33 +64,32 @@
               <q-tooltip>
                 <span class="text--tooltip">{{ $t('assets.wrap') }}</span>
               </q-tooltip>
-            </a>
+            </custom-router-link>
           </div>
 
           <div v-if="isZkEvm">
-            <a
+            <custom-router-link
               v-if="token.bridgeUrl"
-              :href="token.bridgeUrl"
-              target="_blank"
-              rel="noopener noreferrer"
+              :to="token.bridgeUrl"
+              :is-disabled="!isBridgeEnabled(token.bridgeUrl)"
             >
-              <button class="btn btn--icon">
-                <astar-icon-bridge class="icon--bridge" />
-              </button>
+              <button class="btn btn--icon"><astar-icon-bridge class="icon--bridge" /></button>
               <span class="text--expand-menu">{{ $t('assets.bridge') }}</span>
               <q-tooltip>
                 <span class="text--tooltip">{{ $t('assets.bridge') }}</span>
               </q-tooltip>
-            </a>
-            <router-link v-else :to="buildEthereumBridgePageLink()">
-              <button class="btn btn--icon">
-                <astar-icon-bridge class="icon--bridge" />
-              </button>
+            </custom-router-link>
+            <custom-router-link
+              v-else
+              :to="buildEthereumBridgePageLink()"
+              :is-disabled="!nativeBridgeEnabled"
+            >
+              <button class="btn btn--icon"><astar-icon-bridge class="icon--bridge" /></button>
               <span class="text--expand-menu">{{ $t('assets.bridge') }}</span>
               <q-tooltip>
                 <span class="text--tooltip">{{ $t('assets.bridge') }}</span>
               </q-tooltip>
-            </router-link>
+            </custom-router-link>
           </div>
 
           <a :href="explorerLink" target="_blank" rel="noopener noreferrer">
@@ -165,10 +167,13 @@ import { useStore } from 'src/store';
 import { PropType, computed, defineComponent, ref } from 'vue';
 import Jazzicon from 'vue3-jazzicon/src/components';
 import { truncate } from '@astar-network/astar-sdk-core';
+import { nativeBridgeEnabled, isBridgeEnabled } from 'src/features';
+import CustomRouterLink from '../common/CustomRouterLink.vue';
 
 export default defineComponent({
   components: {
     [Jazzicon.name]: Jazzicon,
+    CustomRouterLink,
   },
   props: {
     token: {
@@ -225,11 +230,13 @@ export default defineComponent({
       isTruncate,
       isFavorite,
       isZkEvm,
+      nativeBridgeEnabled,
       truncate,
       buildTransferPageLink,
       addToEvmProvider,
       handleDeleteStoredToken,
       buildEthereumBridgePageLink,
+      isBridgeEnabled,
     };
   },
 });

--- a/src/components/assets/EvmAssetList.vue
+++ b/src/components/assets/EvmAssetList.vue
@@ -43,7 +43,7 @@
   </div>
 </template>
 <script lang="ts">
-import { cbridgeAppLink, checkIsCbridgeToken } from 'src/c-bridge';
+import { checkIsCbridgeToken } from 'src/c-bridge';
 import AssetSearchOption from 'src/components/assets/AssetSearchOption.vue';
 import Erc20Currency from 'src/components/assets/Erc20Currency.vue';
 import EvmCbridgeToken from 'src/components/assets/EvmCbridgeToken.vue';
@@ -141,7 +141,6 @@ export default defineComponent({
       isSearch,
       search,
       filteredTokens,
-      cbridgeAppLink,
       isHideSmallBalances,
       isDarkTheme,
       icon_img,

--- a/src/components/assets/EvmCbridgeToken.vue
+++ b/src/components/assets/EvmCbridgeToken.vue
@@ -39,15 +39,13 @@
 
       <q-slide-transition :duration="150">
         <div v-show="isExpand || width >= screenSize.sm" class="row__right">
-          <router-link :to="buildTransferPageLink(token.symbol)">
-            <button class="btn btn--icon">
-              <astar-icon-transfer />
-            </button>
+          <custom-router-link :to="buildTransferPageLink(token.symbol)">
+            <button class="btn btn--icon"><astar-icon-transfer /></button>
             <span class="text--expand-menu">{{ $t('assets.send') }}</span>
             <q-tooltip>
               <span class="text--tooltip">{{ $t('assets.send') }}</span>
             </q-tooltip>
-          </router-link>
+          </custom-router-link>
 
           <div>
             <button
@@ -125,10 +123,12 @@ import Jazzicon from 'vue3-jazzicon/src/components';
 import { truncate } from '@astar-network/astar-sdk-core';
 import { celerBridgeEnabled } from 'src/features';
 import { navigateInNewTab } from 'src/util-general';
+import CustomRouterLink from '../common/CustomRouterLink.vue';
 
 export default defineComponent({
   components: {
     [Jazzicon.name]: Jazzicon,
+    CustomRouterLink,
   },
   props: {
     token: {

--- a/src/components/assets/EvmCbridgeToken.vue
+++ b/src/components/assets/EvmCbridgeToken.vue
@@ -49,24 +49,19 @@
             </q-tooltip>
           </router-link>
 
-          <!-- <a :href="cbridgeAppLink" target="_blank" rel="noopener noreferrer">
-            <button class="btn btn--icon">
+          <div>
+            <button
+              class="btn btn--icon"
+              :disabled="!celerBridgeEnabled"
+              @click="navigateInNewTab(cbridgeAppLink)"
+            >
               <astar-icon-bridge class="icon--bridge" />
             </button>
             <span class="text--expand-menu">{{ $t('assets.bridge') }}</span>
             <q-tooltip>
               <span class="text--tooltip">{{ $t('assets.bridge') }}</span>
             </q-tooltip>
-          </a> -->
-          <a>
-            <button class="btn btn--icon" disabled>
-              <astar-icon-bridge class="icon--bridge" />
-            </button>
-            <span class="text--expand-menu">{{ $t('assets.bridge') }}</span>
-            <q-tooltip>
-              <span class="text--tooltip">{{ $t('assets.bridge') }}</span>
-            </q-tooltip>
-          </a>
+          </div>
 
           <a :href="explorerLink" target="_blank" rel="noopener noreferrer">
             <button class="btn btn--icon">
@@ -127,8 +122,9 @@ import { computed, defineComponent, PropType, ref } from 'vue';
 import { buildTransferPageLink } from 'src/router/routes';
 import { useNetworkInfo, useBreakpoints } from 'src/hooks';
 import Jazzicon from 'vue3-jazzicon/src/components';
-import TokenBalance from 'src/components/common/TokenBalance.vue';
 import { truncate } from '@astar-network/astar-sdk-core';
+import { celerBridgeEnabled } from 'src/features';
+import { navigateInNewTab } from 'src/util-general';
 
 export default defineComponent({
   components: {
@@ -185,10 +181,12 @@ export default defineComponent({
       isExpand,
       isTruncate,
       isFavorite,
+      celerBridgeEnabled,
       truncate,
       buildTransferPageLink,
       formatTokenName,
       addToEvmProvider,
+      navigateInNewTab,
     };
   },
 });

--- a/src/components/assets/EvmNativeToken.vue
+++ b/src/components/assets/EvmNativeToken.vue
@@ -43,33 +43,29 @@
           </q-tooltip>
         </router-link>
 
-        <router-link
+        <custom-router-link
           v-if="isAstar"
           :to="buildLzBridgePageLink()"
-          :disabled="!layerZeroBridgeEnabled"
+          :is-disabled="!layerZeroBridgeEnabled"
         >
-          <button class="btn btn--icon">
-            <astar-icon-bridge />
-          </button>
+          <button class="btn btn--icon"><astar-icon-bridge /></button>
           <span class="text--mobile-menu">{{ $t('assets.bridge') }}</span>
           <q-tooltip>
             <span class="text--tooltip">{{ $t('assets.bridge') }}</span>
           </q-tooltip>
-        </router-link>
+        </custom-router-link>
 
-        <router-link
+        <custom-router-link
           v-if="isZkEvm"
           :to="buildEthereumBridgePageLink()"
-          :disabled="!nativeBridgeEnabled"
+          :is-disabled="!nativeBridgeEnabled"
         >
-          <button class="btn btn--icon">
-            <astar-icon-bridge />
-          </button>
+          <button class="btn btn--icon"><astar-icon-bridge /></button>
           <span class="text--mobile-menu">{{ $t('assets.bridge') }}</span>
           <q-tooltip>
             <span class="text--tooltip">{{ $t('assets.bridge') }}</span>
           </q-tooltip>
-        </router-link>
+        </custom-router-link>
 
         <!-- Only SDN is able to bridge via cBridge at this moment -->
         <!-- <a
@@ -138,9 +134,10 @@ import {
 import { useStore } from 'src/store';
 import { computed, defineComponent, ref, watchEffect } from 'vue';
 import { nativeBridgeEnabled, layerZeroBridgeEnabled } from 'src/features';
+import CustomRouterLink from '../common/CustomRouterLink.vue';
 
 export default defineComponent({
-  components: { ModalFaucet },
+  components: { ModalFaucet, CustomRouterLink },
   props: {
     nativeTokenUsd: {
       type: Number,

--- a/src/components/assets/EvmNativeToken.vue
+++ b/src/components/assets/EvmNativeToken.vue
@@ -43,7 +43,11 @@
           </q-tooltip>
         </router-link>
 
-        <router-link v-if="isAstar" :to="buildLzBridgePageLink()">
+        <router-link
+          v-if="isAstar"
+          :to="buildLzBridgePageLink()"
+          :disabled="!layerZeroBridgeEnabled"
+        >
           <button class="btn btn--icon">
             <astar-icon-bridge />
           </button>
@@ -53,7 +57,11 @@
           </q-tooltip>
         </router-link>
 
-        <router-link v-if="isZkEvm" :to="buildEthereumBridgePageLink()">
+        <router-link
+          v-if="isZkEvm"
+          :to="buildEthereumBridgePageLink()"
+          :disabled="!nativeBridgeEnabled"
+        >
           <button class="btn btn--icon">
             <astar-icon-bridge />
           </button>
@@ -129,6 +137,7 @@ import {
 } from 'src/router/routes';
 import { useStore } from 'src/store';
 import { computed, defineComponent, ref, watchEffect } from 'vue';
+import { nativeBridgeEnabled, layerZeroBridgeEnabled } from 'src/features';
 
 export default defineComponent({
   components: { ModalFaucet },
@@ -208,6 +217,8 @@ export default defineComponent({
       screenSize,
       isTruncate,
       isAstar,
+      nativeBridgeEnabled,
+      layerZeroBridgeEnabled,
       truncate,
       handleModalFaucet,
       buildTransferPageLink,

--- a/src/components/assets/ZkAstr.vue
+++ b/src/components/assets/ZkAstr.vue
@@ -42,7 +42,12 @@
           </q-tooltip>
         </router-link>
 
-        <router-link v-if="t.symbol === 'ASTR'" :to="buildLzBridgePageLink()" class="box--icon">
+        <custom-router-link
+          v-if="t.symbol === 'ASTR'"
+          :to="buildLzBridgePageLink()"
+          :is-disabled="!layerZeroBridgeEnabled"
+          class="box--icon"
+        >
           <button class="btn btn--icon">
             <astar-icon-bridge />
           </button>
@@ -50,9 +55,14 @@
           <q-tooltip>
             <span class="text--tooltip">{{ $t('assets.bridge') }}</span>
           </q-tooltip>
-        </router-link>
+        </custom-router-link>
 
-        <a v-else :href="vAstrOmniLink" target="_blank" rel="noopener noreferrer" class="box--icon">
+        <custom-router-link
+          v-else
+          :to="vAstrOmniLink"
+          :is-disabled="!omniBridgeEnabled"
+          class="box--icon"
+        >
           <button class="btn btn--icon">
             <astar-icon-bridge />
           </button>
@@ -60,7 +70,7 @@
           <q-tooltip>
             <span class="text--tooltip">{{ $t('assets.swap') }}</span>
           </q-tooltip>
-        </a>
+        </custom-router-link>
 
         <a
           :href="getExplorerLink(t.address)"
@@ -115,9 +125,11 @@ import { Erc20Token, getErc20Explorer } from 'src/modules/token';
 import { buildTransferPageLink, buildLzBridgePageLink } from 'src/router/routes';
 import { PropType, defineComponent } from 'vue';
 import { vAstrOmniLink } from '../../modules/zk-evm-bridge';
+import CustomRouterLink from 'src/components/common/CustomRouterLink.vue';
+import { layerZeroBridgeEnabled, omniBridgeEnabled } from 'src/features';
 
 export default defineComponent({
-  components: {},
+  components: { CustomRouterLink },
   props: {
     astrTokens: {
       type: Array as PropType<Erc20Token[]>,
@@ -140,6 +152,8 @@ export default defineComponent({
       addToEvmProvider,
       buildTransferPageLink,
       getExplorerLink,
+      layerZeroBridgeEnabled,
+      omniBridgeEnabled,
     };
   },
 });

--- a/src/components/bridge/BridgeSelection.vue
+++ b/src/components/bridge/BridgeSelection.vue
@@ -6,9 +6,9 @@
       </div>
       <div class="container--selection">
         <div class="column--selection">
-          <button :disabled="!isEnableEthBridge || isBridgeMaintenanceMode">
+          <button :disabled="!isEnableEthBridge">
             <component
-              :is="isEnableEthBridge && !isBridgeMaintenanceMode ? 'router-link' : 'div'"
+              :is="isEnableEthBridge ? 'router-link' : 'div'"
               :to="buildEthereumBridgePageLink()"
               class="button--bridge"
             >
@@ -36,18 +36,18 @@
               </div>
             </component>
           </button>
-          <p v-if="!isEnableEthBridge" class="text--bridge-details">
+          <p v-if="!isZkEvm" class="text--bridge-details">
             {{ $t('bridge.ethereumBridge.text2') }}
           </p>
-          <p v-if="isBridgeMaintenanceMode" class="text--bridge-details">
+          <p v-if="!nativeBridgeEnabled" class="text--bridge-details">
             {{ $t('bridge.bridgeMaintenanceMode') }}
           </p>
         </div>
 
         <div class="column--selection">
-          <button :disabled="!isEnableLzBridge || isBridgeMaintenanceMode">
+          <button :disabled="!isEnableLzBridge || !layerZeroBridgeEnabled">
             <component
-              :is="isEnableLzBridge && !isBridgeMaintenanceMode ? 'router-link' : 'div'"
+              :is="isEnableLzBridge && layerZeroBridgeEnabled ? 'router-link' : 'div'"
               :to="buildLzBridgePageLink()"
               class="button--bridge"
             >
@@ -78,7 +78,7 @@
           <p v-if="!isEnableLzBridge" class="text--bridge-details">
             {{ $t('bridge.astarBridge.text2') }}
           </p>
-          <p v-if="isBridgeMaintenanceMode" class="text--bridge-details">
+          <p v-if="!layerZeroBridgeEnabled" class="text--bridge-details">
             {{ $t('bridge.bridgeMaintenanceMode') }}
           </p>
         </div>
@@ -118,76 +118,69 @@
       </div>
       <div class="container--selection">
         <div class="column--selection">
-          <button>
-            <a
-              :href="layerSwapLink"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="button--bridge"
-            >
-              <div class="row--logo-bg">
-                <div class="img--logo-bg">
-                  <img
-                    class="img--logo"
-                    :src="require('src/assets/img/layerswap_logo.svg')"
-                    alt="layer-swap"
-                  />
-                </div>
+          <button
+            :disabled="!layerSwapBridgeEnabled"
+            class="button--bridge"
+            @click="navigateInNewTab(layerSwapLink)"
+          >
+            <div class="row--logo-bg">
+              <div class="img--logo-bg">
+                <img
+                  class="img--logo"
+                  :src="require('src/assets/img/layerswap_logo.svg')"
+                  alt="layer-swap"
+                />
               </div>
-              <div class="row--bridge-title">
-                <div class="text--bridge-tag">
-                  <q-chip outline>
-                    {{ $t('bridge.layerSwap.tag') }}
-                  </q-chip>
-                </div>
-                <span class="text--bridge-title">{{ $t('bridge.layerSwap.title') }}</span>
-                <div class="box--text-bridge">
-                  <span class="text--bridge">
-                    {{ $t('bridge.layerSwap.text') }}
-                  </span>
-                </div>
+            </div>
+            <div class="row--bridge-title">
+              <div class="text--bridge-tag">
+                <q-chip outline>
+                  {{ $t('bridge.layerSwap.tag') }}
+                </q-chip>
               </div>
-            </a>
+              <span class="text--bridge-title">{{ $t('bridge.layerSwap.title') }}</span>
+              <div class="box--text-bridge">
+                <span class="text--bridge">
+                  {{ $t('bridge.layerSwap.text') }}
+                </span>
+              </div>
+            </div>
           </button>
         </div>
         <div class="column--selection">
-          <button :disabled="!isEnableCelerBridge">
-            <!-- <a
-              :href="cbridgeAppLink"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="button--bridge"
-            > -->
-            <a target="_blank" rel="noopener noreferrer" class="button--bridge">
-              <div class="row--logo-bg">
-                <div class="img--logo-bg">
-                  <img
-                    class="img--logo"
-                    :src="require('src/assets/img/cbridge_logo.svg')"
-                    alt="cbridge"
-                  />
-                </div>
+          <button
+            :disabled="!celerBridgeEnabled"
+            class="button--bridge"
+            @click="navigateInNewTab(cbridgeAppLink)"
+          >
+            <div class="row--logo-bg">
+              <div class="img--logo-bg">
+                <img
+                  class="img--logo"
+                  :src="require('src/assets/img/cbridge_logo.svg')"
+                  alt="cbridge"
+                />
               </div>
-              <div class="row--bridge-title">
-                <div class="text--bridge-tag">
-                  <q-chip outline>
-                    {{ $t('bridge.celerBridge.tag') }}
-                  </q-chip>
-                </div>
-                <span class="text--bridge-title">{{ $t('bridge.celerBridge.title') }}</span>
-                <div class="box--text-bridge">
-                  <span class="text--bridge">
-                    {{
-                      $t('bridge.celerBridge.text', {
-                        cbridgeNetworkName,
-                      })
-                    }}
-                  </span>
-                </div>
+            </div>
+            <div class="row--bridge-title">
+              <div class="text--bridge-tag">
+                <q-chip outline>
+                  {{ $t('bridge.celerBridge.tag') }}
+                </q-chip>
               </div>
-            </a>
+              <span class="text--bridge-title">{{ $t('bridge.celerBridge.title') }}</span>
+              <div class="box--text-bridge">
+                <span class="text--bridge">
+                  {{
+                    $t('bridge.celerBridge.text', {
+                      cbridgeNetworkName,
+                    })
+                  }}
+                </span>
+              </div>
+            </div>
           </button>
-          <p v-if="!isEnableCelerBridge" class="text--bridge-details">
+          <p v-if="!celerBridgeEnabled" class="text--bridge-details">
             {{ $t('bridge.celerBridge.warning') }}
           </p>
         </div>
@@ -206,21 +199,20 @@ import {
 } from 'src/router/routes';
 import { computed, defineComponent } from 'vue';
 import { layerSwapLink, zKatanaBridgeUrl } from 'src/modules/zk-evm-bridge/index';
+import {
+  celerBridgeEnabled,
+  layerSwapBridgeEnabled,
+  nativeBridgeEnabled,
+  layerZeroBridgeEnabled,
+} from 'src/features';
+import { navigateInNewTab } from 'src/util-general';
 
 export default defineComponent({
   components: {},
   setup() {
     const { currentAccount } = useAccount();
-    const {
-      isZkEvm,
-      networkNameSubstrate,
-      isMainnet,
-      isZkyoto,
-      isAstarZkEvm,
-      isAstar,
-      isH160,
-      isBridgeMaintenanceMode,
-    } = useNetworkInfo();
+    const { isZkEvm, networkNameSubstrate, isMainnet, isZkyoto, isAstarZkEvm, isAstar, isH160 } =
+      useNetworkInfo();
 
     const l1Name = computed<string>(() => {
       return isZkyoto.value ? EthBridgeNetworkName.Sepolia : EthBridgeNetworkName.Ethereum;
@@ -234,35 +226,32 @@ export default defineComponent({
       return !isZkEvm.value && isMainnet.value ? networkNameSubstrate.value : 'Astar';
     });
 
-    const isEnableEthBridge = computed<boolean>(() => {
-      if (!isZkEvm.value) {
-        return false;
-      }
-      return true;
-    });
+    const isEnableEthBridge = computed<boolean>(() => isZkEvm.value && nativeBridgeEnabled);
 
     const isEnableLzBridge = computed<boolean>(() => {
       return isH160.value && (isAstar.value || isAstarZkEvm.value);
     });
-
-    const isEnableCelerBridge = computed<boolean>(() => false);
 
     return {
       currentAccount,
       cbridgeAppLink,
       RoutePath,
       isEnableEthBridge,
+      isZkEvm,
       l1Name,
       l2Name,
       cbridgeNetworkName,
-      buildEthereumBridgePageLink,
-      buildLzBridgePageLink,
       layerSwapLink,
       zKatanaBridgeUrl,
       isZkyoto,
       isEnableLzBridge,
-      isBridgeMaintenanceMode,
-      isEnableCelerBridge,
+      celerBridgeEnabled,
+      layerSwapBridgeEnabled,
+      nativeBridgeEnabled,
+      layerZeroBridgeEnabled,
+      buildEthereumBridgePageLink,
+      buildLzBridgePageLink,
+      navigateInNewTab,
     };
   },
 });

--- a/src/components/bridge/layerzero/LzBridge.vue
+++ b/src/components/bridge/layerzero/LzBridge.vue
@@ -138,7 +138,7 @@
         </ul>
       </div>
 
-      <div v-if="isBridgeMaintenanceMode" class="row--box-error">
+      <div v-if="!layerZeroBridgeEnabled" class="row--box-error">
         <span class="color--white">
           {{ $t('bridge.underMaintenance') }}
         </span>
@@ -148,7 +148,7 @@
         <astar-button
           class="button--confirm"
           :disabled="
-            isApproved || isDisabledBridge || isHandling || isLoading || isBridgeMaintenanceMode
+            isApproved || isDisabledBridge || isHandling || isLoading || !layerZeroBridgeEnabled
           "
           @click="approve"
         >
@@ -157,7 +157,7 @@
         <astar-button
           class="button--confirm"
           :disabled="
-            !isApproved || isDisabledBridge || isHandling || isLoading || isBridgeMaintenanceMode
+            !isApproved || isDisabledBridge || isHandling || isLoading || !layerZeroBridgeEnabled
           "
           @click="bridge"
         >
@@ -172,12 +172,13 @@
 import { truncate } from '@astar-network/astar-sdk-core';
 import { isHex } from '@polkadot/util';
 import TokenBalance from 'src/components/common/TokenBalance.vue';
-import { useAccount, useNetworkInfo } from 'src/hooks';
+import { useAccount } from 'src/hooks';
 import { EthBridgeNetworkName, LayerZeroToken, lzBridgeIcon } from 'src/modules/zk-evm-bridge';
 import { useStore } from 'src/store';
 import { PropType, computed, defineComponent, ref, watch } from 'vue';
 import Jazzicon from 'vue3-jazzicon/src/components';
 import { LayerZeroNetworkName, LayerZeroSlippage } from '../../../modules/zk-evm-bridge/layerzero';
+import { layerZeroBridgeEnabled } from 'src/features';
 
 export default defineComponent({
   components: {
@@ -260,7 +261,6 @@ export default defineComponent({
   },
   setup(props) {
     const { currentAccount } = useAccount();
-    const { isBridgeMaintenanceMode } = useNetworkInfo();
     const nativeTokenSymbol = computed<string>(() => {
       return props.fromChainName === LayerZeroNetworkName.AstarEvm ? 'ASTR' : 'ETH';
     });
@@ -318,10 +318,10 @@ export default defineComponent({
       isEnabledWithdrawal,
       LayerZeroSlippage,
       nativeTokenSymbol,
+      layerZeroBridgeEnabled,
       truncate,
       bridge,
       approve,
-      isBridgeMaintenanceMode,
     };
   },
 });

--- a/src/components/bridge/styles/bridge-selection.scss
+++ b/src/components/bridge/styles/bridge-selection.scss
@@ -99,6 +99,7 @@
   display: flex;
   justify-content: flex-end;
   margin-bottom: 0px;
+  width: 100%;
 }
 
 .img--logo-bg {

--- a/src/components/common/CustomRouterLink.vue
+++ b/src/components/common/CustomRouterLink.vue
@@ -1,0 +1,48 @@
+<template>
+  <div :class="{ disabled: isDisabled }" @click="handleClick">
+    <slot />
+  </div>
+</template>
+
+<script lang="ts">
+import { computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { defineComponent } from 'vue';
+import { navigateInNewTab } from 'src/util-general';
+
+export default defineComponent({
+  props: {
+    to: {
+      type: String,
+      required: true,
+    },
+    isDisabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  setup(props) {
+    const router = useRouter();
+
+    const isExternalLink = computed(() => {
+      return typeof props.to === 'string' && props.to.startsWith('http');
+    });
+
+    const handleClick = (event: MouseEvent) => {
+      if (props.isDisabled) {
+        event.preventDefault();
+      } else {
+        if (isExternalLink.value) {
+          navigateInNewTab(props.to);
+        } else {
+          router.push(props.to);
+        }
+      }
+    };
+
+    return {
+      handleClick,
+    };
+  },
+});
+</script>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,9 @@
 export enum HttpCodes {
   NotFound = 404,
 }
+
+export const PERIOD1_START_BLOCKS = new Map<string, number>([
+  ['astar', 5514935],
+  ['shiden', 5876079],
+  ['shibuya', 5335616],
+]);

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,0 @@
-export const PERIOD1_START_BLOCKS = new Map<string, number>([
-  ['astar', 5514935],
-  ['shiden', 5876079],
-  ['shibuya', 5335616],
-]);

--- a/src/features.ts
+++ b/src/features.ts
@@ -10,13 +10,13 @@ export const arthSwapBridgeEnabled = true;
 
 export const isBridgeEnabled = (bridgeUrl?: string): boolean => {
   switch (true) {
-    case bridgeUrl?.includes('https://stargate.finance'):
+    case bridgeUrl?.includes('stargate'):
       return stargateBridgeEnabled;
-    case bridgeUrl?.includes('https://app.stakestone.io'):
+    case bridgeUrl?.includes('stakestone'):
       return stakeStoneBridgeEnabled;
-    case bridgeUrl?.includes('https://app.arthswap.org'):
+    case bridgeUrl?.includes('arthswap'):
       return arthSwapBridgeEnabled;
-    case bridgeUrl?.includes('https://cbridge.celer.network'):
+    case bridgeUrl?.includes('cbridge'):
       return celerBridgeEnabled;
     default:
       return false;

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,8 +1,8 @@
 // Bridges
-export const nativeBridgeEnabled = false;
-export const layerZeroBridgeEnabled = false;
-export const layerSwapBridgeEnabled = false;
-export const celerBridgeEnabled = false;
+export const nativeBridgeEnabled = true;
+export const layerZeroBridgeEnabled = true;
+export const layerSwapBridgeEnabled = true;
+export const celerBridgeEnabled = true;
 export const omniBridgeEnabled = true;
 const stargateBridgeEnabled = true;
 const stakeStoneBridgeEnabled = true;

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,8 +1,27 @@
 // Bridges
-export const nativeBridgeEnabled = false;
-export const layerZeroBridgeEnabled = false;
-export const layerSwapBridgeEnabled = false;
-export const celerBridgeEnabled = false;
+export const nativeBridgeEnabled = true;
+export const layerZeroBridgeEnabled = true;
+export const layerSwapBridgeEnabled = true;
+export const celerBridgeEnabled = true;
+export const omniBridgeEnabled = true;
+export const stargateBridgeEnabled = true;
+export const stakeStoneBridgeEnabled = true;
+export const arthSwapBridgeEnabled = true;
 
-// XCM
-export const xcmEnabled = true;
+export const isBridgeEnabled = (bridgeUrl?: string): boolean => {
+  switch (true) {
+    case bridgeUrl?.includes('stargate.finance'):
+      return stargateBridgeEnabled;
+    case bridgeUrl?.includes('stakestone.io'):
+      return stakeStoneBridgeEnabled;
+    case bridgeUrl?.includes('arthswap.org'):
+      return arthSwapBridgeEnabled;
+    case bridgeUrl?.includes('cbridge.celer'):
+      return celerBridgeEnabled;
+    default:
+      return false;
+  }
+};
+
+// XCM - TODO in the next PR
+// export const xcmEnabled = true;

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,12 +1,12 @@
 // Bridges
-export const nativeBridgeEnabled = true;
-export const layerZeroBridgeEnabled = true;
-export const layerSwapBridgeEnabled = true;
-export const celerBridgeEnabled = true;
+export const nativeBridgeEnabled = false;
+export const layerZeroBridgeEnabled = false;
+export const layerSwapBridgeEnabled = false;
+export const celerBridgeEnabled = false;
 export const omniBridgeEnabled = true;
-export const stargateBridgeEnabled = true;
-export const stakeStoneBridgeEnabled = true;
-export const arthSwapBridgeEnabled = true;
+const stargateBridgeEnabled = true;
+const stakeStoneBridgeEnabled = true;
+const arthSwapBridgeEnabled = true;
 
 export const isBridgeEnabled = (bridgeUrl?: string): boolean => {
   switch (true) {

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,0 +1,8 @@
+// Bridges
+export const nativeBridgeEnabled = false;
+export const layerZeroBridgeEnabled = false;
+export const layerSwapBridgeEnabled = false;
+export const celerBridgeEnabled = false;
+
+// XCM
+export const xcmEnabled = true;

--- a/src/features.ts
+++ b/src/features.ts
@@ -10,13 +10,13 @@ export const arthSwapBridgeEnabled = true;
 
 export const isBridgeEnabled = (bridgeUrl?: string): boolean => {
   switch (true) {
-    case bridgeUrl?.includes('stargate.finance'):
+    case bridgeUrl?.includes('https://stargate.finance'):
       return stargateBridgeEnabled;
-    case bridgeUrl?.includes('stakestone.io'):
+    case bridgeUrl?.includes('https://app.stakestone.io'):
       return stakeStoneBridgeEnabled;
-    case bridgeUrl?.includes('arthswap.org'):
+    case bridgeUrl?.includes('https://app.arthswap.org'):
       return arthSwapBridgeEnabled;
-    case bridgeUrl?.includes('cbridge.celer'):
+    case bridgeUrl?.includes('https://cbridge.celer.network'):
       return celerBridgeEnabled;
     default:
       return false;

--- a/src/hooks/bridge/useL1Bridge.ts
+++ b/src/hooks/bridge/useL1Bridge.ts
@@ -23,6 +23,7 @@ import { useEthProvider } from '../custom-signature/useEthProvider';
 import { EthereumProvider } from '../types/CustomSignature';
 import { Path } from 'src/router';
 import { useRouter } from 'vue-router';
+import { nativeBridgeEnabled } from 'src/features';
 
 const eth = {
   symbol: 'ETH',
@@ -80,7 +81,6 @@ export const useL1Bridge = () => {
   const { currentAccount } = useAccount();
   const { web3Provider, ethProvider } = useEthProvider();
   const router = useRouter();
-  const { isBridgeMaintenanceMode } = useNetworkInfo();
 
   const isLoading = computed<boolean>(() => store.getters['general/isLoading']);
   const fromChainId = computed<number>(
@@ -423,7 +423,7 @@ export const useL1Bridge = () => {
 
   // Memo: the app goes to assets page if users access to the bridge page by inputting URL directly
   watchEffect(() => {
-    if (isBridgeMaintenanceMode.value) {
+    if (!nativeBridgeEnabled) {
       router.push(Path.Assets);
     }
   });

--- a/src/hooks/useInflation.ts
+++ b/src/hooks/useInflation.ts
@@ -13,7 +13,7 @@ import { InflationConfiguration } from 'src/v2/models';
 import { InflationParam, useDappStaking } from 'src/staking-v3';
 import { ethers } from 'ethers';
 import { useNetworkInfo } from './useNetworkInfo';
-import { PERIOD1_START_BLOCKS } from 'src/consts';
+import { PERIOD1_START_BLOCKS } from 'src/constants';
 
 type UseInflation = {
   activeInflationConfiguration: ComputedRef<InflationConfiguration>;

--- a/src/hooks/useNetworkInfo.ts
+++ b/src/hooks/useNetworkInfo.ts
@@ -112,10 +112,6 @@ export function useNetworkInfo() {
       : shibuya;
   });
 
-  const isBridgeMaintenanceMode = computed<boolean>(() => {
-    return false;
-  });
-
   return {
     isMainnet,
     currentNetworkChain,
@@ -133,6 +129,5 @@ export function useNetworkInfo() {
     dappStakingCurrency,
     isH160,
     nativeTokenImg,
-    isBridgeMaintenanceMode,
   };
 }

--- a/src/staking-v3/hooks/usePeriodStats.ts
+++ b/src/staking-v3/hooks/usePeriodStats.ts
@@ -5,7 +5,7 @@ import { IBalancesRepository, ITokenApiRepository, PeriodData } from 'src/v2/rep
 import { Symbols } from 'src/v2/symbols';
 import { useDapps } from './useDapps';
 import { DappState, IDappStakingRepository, IDappStakingService } from '../logic';
-import { PERIOD1_START_BLOCKS } from 'src/consts';
+import { PERIOD1_START_BLOCKS } from 'src/constants';
 import { useDappStaking } from './useDappStaking';
 import { useDataCalculations } from './useDataCalculations';
 import { ethers } from 'ethers';

--- a/src/util-general.ts
+++ b/src/util-general.ts
@@ -1,0 +1,3 @@
+export const navigateInNewTab = (url: string): void => {
+  window.open(url, '_blank', 'noopener noreferrer');
+};


### PR DESCRIPTION
**Pull Request Summary**

This is the first PR to centralize the portal configuration and simply enable/disable certain features, like bridges or XCM

Configuration is stored in `fetures.ts` and settings looks like
```
// Bridges
export const nativeBridgeEnabled = true;
export const layerZeroBridgeEnabled = true;
export const layerSwapBridgeEnabled = true;
export const celerBridgeEnabled = true;
export const omniBridgeEnabled = true;
export const stargateBridgeEnabled = true;
export const stakeStoneBridgeEnabled = true;
export const arthSwapBridgeEnabled = true;
```

The portal code is updated to take those settings into consideration. 
I found that disabling `router-link`, so I created replacement component in `CustomRouterLink.vue`

**Check list**

- [ ] contains breaking changes
- [x] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
