### PR TITLE
Fix: estimated realized inflation not showing

### DIFF
--- a/src/staking-v3/components/data/DataList.vue
+++ b/src/staking-v3/components/data/DataList.vue
@@ -127,7 +127,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from 'vue';
+import { defineComponent, computed, onMounted } from 'vue';
 import { useDataCalculations } from 'src/staking-v3/hooks';
 import DataCard from './DataCard.vue';
 import { useDappStaking, useDapps, usePeriod } from 'src/staking-v3/hooks';
@@ -154,7 +154,8 @@ export default defineComponent({
       numberOfStakersAndLockers,
       tokensToBeBurned,
     } = useDataCalculations();
-    const { activeInflationConfiguration, estimatedInflation } = useInflation();
+    const { activeInflationConfiguration, estimatedInflation, estimateRealizedInflation } =
+      useInflation();
 
     const totalDapps = computed<number>(() => registeredDapps.value?.length ?? 0);
     const tvl = computed<string>(() => (currentEraInfo.value?.totalLocked ?? BigInt(0)).toString());
@@ -181,6 +182,10 @@ export default defineComponent({
     const estimatedInflationFormatted = computed<string>(() =>
       estimatedInflation.value ? `${estimatedInflation.value.toFixed(2)} %` : '--'
     );
+
+    onMounted(() => {
+      estimateRealizedInflation();
+    });
 
     return {
       protocolState,


### PR DESCRIPTION
**Pull Request Summary**

Realized estimated inflation was not showing on dApp staking data panel

BEFORE
<img width="299" alt="image" src="https://github.com/user-attachments/assets/154f0909-cda2-4a2b-b282-dd800640acf2">


AFTER
<img width="296" alt="image" src="https://github.com/user-attachments/assets/863c693c-ff59-40d4-9d75-9d807c6e0379">


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

