### PR TITLE
Re-try fetch from cbridge

### DIFF
--- a/src/v2/repositories/implementations/EvmAssetsRepository.ts
+++ b/src/v2/repositories/implementations/EvmAssetsRepository.ts
@@ -56,6 +56,7 @@ export class EvmAssetsRepository implements IEvmAssetsRepository {
     isFetchUsd: boolean;
   }): Promise<Erc20Token[]> {
     Guard.ThrowIfUndefined('currentAccount', currentAccount);
+    const numberOfRetries = 2;
 
     if (
       String(srcChainId) === providerEndpoints[endpointKey.SHIBUYA].evmChainId ||
@@ -67,43 +68,48 @@ export class EvmAssetsRepository implements IEvmAssetsRepository {
       return [];
     }
 
-    const data = await getTransferConfigs(currentNetworkIdx);
-    if (!data || !data.tokens) {
-      throw Error('Cannot fetch from cBridge API');
+    for (let i = 0; i < numberOfRetries; i++) {
+      const data = await getTransferConfigs(currentNetworkIdx);
+      if (!data || !data.tokens) {
+        continue;
+      }
+
+      const seen = new Set();
+      // Todo: use srcChain and destChainID to re-define token information for bridging (ex: PKEX)
+
+      const tokens = (await Promise.all(
+        objToArray(data.tokens[srcChainId as EvmChain])
+          .flat()
+          .map(async (token: CbridgeToken) => {
+            const t = getSelectedToken({ srcChainId, token });
+            if (!t) return undefined;
+            const formattedToken = castCbridgeToErc20({ srcChainId, token: t });
+            const isDuplicated = seen.has(formattedToken.address);
+            seen.add(formattedToken.address);
+            // Memo: Remove the duplicated contract address (ex: PKEX)
+            if (isDuplicated) return undefined;
+
+            const { balUsd, userBalance } = await this.updateTokenBalanceHandler({
+              userAddress: currentAccount,
+              token: formattedToken,
+              isFetchUsd,
+              srcChainId,
+            });
+            const tokenWithBalance = {
+              ...formattedToken,
+              userBalance,
+              userBalanceUsd: String(balUsd),
+            };
+            return castCbridgeTokenData(tokenWithBalance);
+          })
+      )) as Erc20Token[];
+
+      return tokens.filter((token) => {
+        return token !== undefined;
+      });
     }
-    const seen = new Set();
-    // Todo: use srcChain and destChainID to re-define token information for bridging (ex: PKEX)
 
-    const tokens = (await Promise.all(
-      objToArray(data.tokens[srcChainId as EvmChain])
-        .flat()
-        .map(async (token: CbridgeToken) => {
-          const t = getSelectedToken({ srcChainId, token });
-          if (!t) return undefined;
-          const formattedToken = castCbridgeToErc20({ srcChainId, token: t });
-          const isDuplicated = seen.has(formattedToken.address);
-          seen.add(formattedToken.address);
-          // Memo: Remove the duplicated contract address (ex: PKEX)
-          if (isDuplicated) return undefined;
-
-          const { balUsd, userBalance } = await this.updateTokenBalanceHandler({
-            userAddress: currentAccount,
-            token: formattedToken,
-            isFetchUsd,
-            srcChainId,
-          });
-          const tokenWithBalance = {
-            ...formattedToken,
-            userBalance,
-            userBalanceUsd: String(balUsd),
-          };
-          return castCbridgeTokenData(tokenWithBalance);
-        })
-    )) as Erc20Token[];
-
-    return tokens.filter((token) => {
-      return token !== undefined;
-    });
+    throw Error('Cannot fetch from cBridge API');
   }
 
   public async fetchRegisteredAssets({


### PR DESCRIPTION
**Pull Request Summary**

This is PR is to re-try fetching data from cbridge API. I noticed that recently first request to their API started to fail, but 2nd one works fine. 

Because of that issue assets page spins forever when user is connected with EVM wallet
![image](https://github.com/user-attachments/assets/4ed2e0fb-31d8-43b1-8b3c-b6cdff40b2af)

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
