### PR TITLE
APR calculation fix to use block time for a given block

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,8 @@ export enum HttpCodes {
   NotFound = 404,
 }
 
+export const ORIGINAL_BLOCK_TIME = 12;
+
 export const PERIOD1_START_BLOCKS = new Map<string, number>([
   ['astar', 5514935],
   ['shiden', 5876079],

--- a/src/staking-v3/logic/services/DappStakingService.ts
+++ b/src/staking-v3/logic/services/DappStakingService.ts
@@ -717,7 +717,7 @@ export class DappStakingService extends SignerService implements IDappStakingSer
         this.dappStakingRepository.getEraLengths(block),
         this.dappStakingRepository.getCurrentEraInfo(block),
         this.dappStakingRepository.getProtocolState(block),
-        this.systemRepository.getBlockTimeInSeconds(),
+        this.systemRepository.getBlockTimeInSeconds(block),
       ]);
 
     const cyclesPerYear = this.getCyclesPerYear(eraLengths, blockTime);
@@ -746,7 +746,7 @@ export class DappStakingService extends SignerService implements IDappStakingSer
         this.dappStakingRepository.getEraLengths(block),
         this.dappStakingRepository.getCurrentEraInfo(block),
         this.dappStakingRepository.getProtocolState(block),
-        this.systemRepository.getBlockTimeInSeconds(),
+        this.systemRepository.getBlockTimeInSeconds(block),
       ]);
 
     const cyclesPerYear = this.getCyclesPerYear(eraLengths, blockTime);

--- a/src/v2/repositories/ISystemRepository.ts
+++ b/src/v2/repositories/ISystemRepository.ts
@@ -26,5 +26,5 @@ export interface ISystemRepository {
   /**
    * Gets block time.
    */
-  getBlockTimeInSeconds(): Promise<number>;
+  getBlockTimeInSeconds(blockNumber?: number): Promise<number>;
 }

--- a/src/v2/repositories/implementations/SystemRepository.ts
+++ b/src/v2/repositories/implementations/SystemRepository.ts
@@ -85,7 +85,7 @@ export class SystemRepository implements ISystemRepository {
     const api = await this.api.getApi(blockNumber);
 
     if (api.consts.aura) {
-      const blockTime = <u64>api.consts.aura?.slotDuration;
+      const blockTime = <u64>api.consts.aura.slotDuration;
       return blockTime.toNumber() / 1000;
     }
 

--- a/src/v2/repositories/implementations/SystemRepository.ts
+++ b/src/v2/repositories/implementations/SystemRepository.ts
@@ -7,6 +7,7 @@ import { Symbols } from 'src/v2/symbols';
 import { Struct, u128, u32, u64 } from '@polkadot/types';
 import { EventAggregator, NewBlockMessage } from 'src/v2/messaging';
 import { BlockHash } from '@polkadot/types/interfaces';
+import { ORIGINAL_BLOCK_TIME } from 'src/constants';
 
 export interface FrameSystemAccountInfo extends Struct {
   readonly nonce: u32;
@@ -80,10 +81,14 @@ export class SystemRepository implements ISystemRepository {
     return blockHash;
   }
 
-  public async getBlockTimeInSeconds(): Promise<number> {
-    const api = await this.api.getApi();
-    const blockTime = <u64>api.consts.aura.slotDuration;
+  public async getBlockTimeInSeconds(blockNumber?: number): Promise<number> {
+    const api = await this.api.getApi(blockNumber);
 
-    return blockTime.toNumber() / 1000;
+    if (api.consts.aura) {
+      const blockTime = <u64>api.consts.aura?.slotDuration;
+      return blockTime.toNumber() / 1000;
+    }
+
+    return ORIGINAL_BLOCK_TIME;
   }
 }


### PR DESCRIPTION
**Pull Request Summary**

I made an oversight in #1384 when I forgot to provide block number when fetching block time in APR calculations

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

