### PR TITLE
Fix for re-staking on unregistered dApps

### DIFF
--- a/src/staking-v3/components/my-staking/MyStaking.vue
+++ b/src/staking-v3/components/my-staking/MyStaking.vue
@@ -206,7 +206,7 @@ export default defineComponent({
       formatPeriod,
     } = useDappStaking();
 
-    const bonus = ref<BigInt>(BigInt(0));
+    const bonus = ref<bigint>(BigInt(0));
     const { getEstimatedBonus } = useAprV3({ isWatch: false });
 
     const { navigateToVote } = useDappStakingNavigation();

--- a/src/staking-v3/hooks/useDappStaking.ts
+++ b/src/staking-v3/hooks/useDappStaking.ts
@@ -192,7 +192,7 @@ export function useDappStaking() {
     );
     const staker = await stakingService.getStakerRewards(currentAccount.value);
     const bonus = await stakingService.getBonusRewards(currentAccount.value);
-    store.commit('stakingV3/setRewards', { ...rewards.value, staker, bonus });
+    store.commit('stakingV3/setRewards', { ...rewards.value, staker, bonus: bonus.amount });
     getCurrentEraInfo();
     fetchStakeAmountsToStore();
     await fetchStakerInfoToStore();
@@ -214,7 +214,7 @@ export function useDappStaking() {
       stakingService.getBonusRewards(currentAccount.value),
       stakingService.getDappRewards(dappAddress),
     ]);
-    store.commit('stakingV3/setRewards', { ...rewards.value, staker, bonus, dApp });
+    store.commit('stakingV3/setRewards', { ...rewards.value, staker, bonus: bonus.amount, dApp });
     fetchStakerInfoToStore();
     getCurrentEraInfo();
     fetchStakeAmountsToStore();
@@ -272,7 +272,7 @@ export function useDappStaking() {
       t('stakingV3.claimBonusRewardSuccess')
     );
     const bonus = await stakingService.getBonusRewards(currentAccount.value);
-    store.commit('stakingV3/setRewards', { ...rewards.value, bonus });
+    store.commit('stakingV3/setRewards', { ...rewards.value, bonus: bonus.amount });
   };
 
   const claimDappRewards = async (contractAddress: string): Promise<void> => {
@@ -303,7 +303,7 @@ export function useDappStaking() {
     );
     const staker = await stakingService.getStakerRewards(currentAccount.value);
     const bonus = await stakingService.getBonusRewards(currentAccount.value);
-    store.commit('stakingV3/setRewards', { ...rewards.value, staker, bonus });
+    store.commit('stakingV3/setRewards', { ...rewards.value, staker, bonus: bonus.amount });
   };
 
   const withdraw = async (): Promise<void> => {

--- a/src/staking-v3/hooks/useVote.ts
+++ b/src/staking-v3/hooks/useVote.ts
@@ -1,5 +1,5 @@
 import { Ref, computed, ref, watch } from 'vue';
-import { CombinedDappInfo, DappStakeInfo, DappVote } from '../logic';
+import type { CombinedDappInfo, DappStakeInfo, DappVote } from '../logic';
 import { ethers } from 'ethers';
 import { useAccount, useBalance } from 'src/hooks';
 import { useDappStaking } from './useDappStaking';


### PR DESCRIPTION
**Pull Request Summary**

There was a bug when the system was re-staking rewards to an unregistered dApp. This was happening If user has stakes on a dApp which was unregistered after staking and tries to re-stake rewards. In that case the  below error will occur
![image](https://github.com/user-attachments/assets/9672c727-7e2b-4eeb-9b87-4b98ab1a6368).

Also found and fixed a bug where the whole bonus rewards object was stored to state instead amount.


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
