### PR TITLE
Remove staked contracts check

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -763,7 +763,6 @@ export default {
       NotOperatedDApp: 'dApp is part of dApp staking but is not active anymore.',
       PeriodEndsNextEra:
         'Period ends in the next era. It is not possible to stake in the last era of a period.',
-      TooManyStakedContracts: 'There are too many contract stake entries for the account.',
       TooManyUnlockingChunks:
         'Contract has too many unlocking chunks. Withdraw the existing chunks if possible or wait for current chunks to complete unlocking process to withdraw them.',
       UnavailableStakeFunds:

--- a/src/staking-v3/hooks/useDappStaking.ts
+++ b/src/staking-v3/hooks/useDappStaking.ts
@@ -446,15 +446,6 @@ export function useDappStaking() {
       } else if (stake.amount <= 0) {
         return [false, t('stakingV3.dappStaking.ZeroAmount'), ''];
       } else if (
-        constants.value &&
-        (ledger.value?.contractStakeCount ?? 0) >= constants.value.maxNumberOfStakedContracts
-      ) {
-        return [
-          false,
-          t('stakingV3.dappStaking.TooManyStakedContracts'),
-          docsUrl.dappStakingStaked16Dapps,
-        ];
-      } else if (
         constants.value?.minStakeAmountToken &&
         stake.amount < constants.value.minStakeAmountToken &&
         getStakerInfo(stake.address) === undefined


### PR DESCRIPTION
**Pull Request Summary**

Removed number of staked contracts check from `canStake` method since we are calling `cleanupExpiredEntries` before staking, if needed.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

