### PR TITLE
fix indicator margin for governance item

### DIFF
--- a/src/components/sidenav/SidebarDesktop.vue
+++ b/src/components/sidenav/SidebarDesktop.vue
@@ -132,18 +132,20 @@ export default defineComponent({
     const path = computed(() => router.currentRoute.value.path.split('/')[2]);
 
     const getIndicatorClass = (path: string): string => {
-      switch (path) {
-        case 'dashboard':
-          return 'menu__dashboard';
-        case 'assets':
-          return 'menu__assets';
-        case 'dapp-staking':
-          return 'menu__staking';
-        case 'bridge':
-          return 'menu__bridge';
-        default:
-          return 'menu__staking';
+      let indicatorClassObject: Record<string, string> = {
+        dashboard: 'menu__dashboard',
+        assets: 'menu__assets',
+        'dapp-staking': 'menu__staking',
+        bridge: 'menu__bridge',
+      };
+
+      let indicatorClass = indicatorClassObject[path] ?? 'menu__staking';
+
+      if (isGovernanceEnabled.value) {
+        indicatorClass += ' governance_activated';
       }
+
+      return indicatorClass;
     };
 
     return {

--- a/src/components/sidenav/styles/sidebar-desktop.scss
+++ b/src/components/sidenav/styles/sidebar-desktop.scss
@@ -99,18 +99,34 @@
 // adding -120px to the margin-top to adjust the position because of the lgfm logo
 .menu__assets {
   margin-top: calc(-276px - 120px);
+
+  &.governance_activated {
+    margin-top: calc(-276px - 120px - 46px);
+  }
 }
 
 .menu__dashboard {
   margin-top: calc(-230px - 120px);
+
+  &.governance_activated {
+    margin-top: calc(-230px - 120px - 46px);
+  }
 }
 
 .menu__staking {
   margin-top: calc(-184px - 120px);
+
+  &.governance_activated {
+    margin-top: calc(-184px - 120px - 46px);
+  }
 }
 
 .menu__bridge {
   margin-top: calc(-138px - 120px);
+
+  &.governance_activated {
+    margin-top: calc(-138px - 120px - 46px);
+  }
 }
 
 .dummy-row {


### PR DESCRIPTION
**Pull Request Summary**

> Fix Menu indicator, it has wrong margin top because of the governance item

**AS_IS**
<img width="393" alt="image" src="https://github.com/user-attachments/assets/cb7d1033-8025-4452-9ca6-d59cddff97ee">

**TO_BE**
<img width="423" alt="image" src="https://github.com/user-attachments/assets/3f6494ca-4f3d-413e-8f1e-99d5ece2eba9">


**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**

- FIx desktop indicator
