### PR TITLE
Account NFT loading fix

### DIFF
--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -104,30 +104,30 @@ export const useAccount = () => {
 
     if (mapped) {
       const identityRepository = container.get<IdentityRepository>(Symbols.IdentityRepository);
-      const nftRepository = container.get<INftRepository>(Symbols.NftRepository);
+      // const nftRepository = container.get<INftRepository>(Symbols.NftRepository);
       const identity = await identityRepository.getIdentity(isEvmAddress ? mapped : address);
       const name = identity?.display || '';
 
       let avatarUrl: string | undefined;
       let nft: NftMetadata | undefined;
 
-      const avatarContractAddress = identity?.getAvatarContractAddress();
-      const avatarTokenId = identity?.getAvatarTokenId();
-      if (avatarContractAddress && avatarTokenId) {
-        try {
-          nft = await nftRepository.getNftMetadata(
-            currentNetworkName.value.toLowerCase(),
-            avatarContractAddress,
-            avatarTokenId
-          );
+      // const avatarContractAddress = identity?.getAvatarContractAddress();
+      // const avatarTokenId = identity?.getAvatarTokenId();
+      // if (avatarContractAddress && avatarTokenId) {
+      //   try {
+      //     nft = await nftRepository.getNftMetadata(
+      //       currentNetworkName.value.toLowerCase(),
+      //       avatarContractAddress,
+      //       avatarTokenId
+      //     );
 
-          if (nft) {
-            avatarUrl = getProxiedUrl(nft.image);
-          }
-        } catch (error) {
-          console.error('Unable to fetch nft metadata', error);
-        }
-      }
+      //     if (nft) {
+      //       avatarUrl = getProxiedUrl(nft.image);
+      //     }
+      //   } catch (error) {
+      //     console.error('Unable to fetch nft metadata', error);
+      //   }
+      // }
 
       const account: UnifiedAccount = {
         nativeAddress: isEvmAddress ? mapped : address,

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -114,14 +114,18 @@ export const useAccount = () => {
       const avatarContractAddress = identity?.getAvatarContractAddress();
       const avatarTokenId = identity?.getAvatarTokenId();
       if (avatarContractAddress && avatarTokenId) {
-        nft = await nftRepository.getNftMetadata(
-          currentNetworkName.value.toLowerCase(),
-          avatarContractAddress,
-          avatarTokenId
-        );
+        try {
+          nft = await nftRepository.getNftMetadata(
+            currentNetworkName.value.toLowerCase(),
+            avatarContractAddress,
+            avatarTokenId
+          );
 
-        if (nft) {
-          avatarUrl = getProxiedUrl(nft.image);
+          if (nft) {
+            avatarUrl = getProxiedUrl(nft.image);
+          }
+        } catch (error) {
+          console.error('Unable to fetch nft metadata', error);
         }
       }
 


### PR DESCRIPTION
**Pull Request Summary**

When we are implemented account unification on Shibuya we tried to load an account owned NFT from Token API as avatar. If error happens while fetching from the API accounts were not shown.

This PR fixes the above behaviour


UPDATE
Just found out that Bluez is deprecating all their services. Since we are using their API for NFT fetching I commented out the code until find out other provider

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

