### PR TITLE
Fix for breaking change in runtime

### DIFF
--- a/src/staking-v3/logic/interfaces/DappStakingV3.ts
+++ b/src/staking-v3/logic/interfaces/DappStakingV3.ts
@@ -86,6 +86,7 @@ export interface PalletDappStakingV3StakeAmount extends Struct {
 export interface PalletDappStakingV3SingularStakingInfo extends Struct {
   readonly staked: PalletDappStakingV3StakeAmount;
   readonly loyalStaker: bool;
+  readonly bonusStatus: u8;
 }
 
 export interface PalletDappStakingV3PeriodEndInfo extends Struct {

--- a/src/staking-v3/logic/repositories/DappStakingRepository.ts
+++ b/src/staking-v3/logic/repositories/DappStakingRepository.ts
@@ -655,7 +655,9 @@ export class DappStakingRepository implements IDappStakingRepository {
           (unwrappedValue.staked.period.toNumber() === currentPeriod || includePreviousPeriods)
         ) {
           result.set(address, <SingularStakingInfo>{
-            loyalStaker: unwrappedValue.loyalStaker.isTrue,
+            loyalStaker: unwrappedValue.loyalStaker
+              ? unwrappedValue.loyalStaker.isTrue
+              : unwrappedValue.bonusStatus.toNumber() > 0,
             staked: this.mapStakeAmount(unwrappedValue.staked),
           });
         }


### PR DESCRIPTION
**Pull Request Summary**

New runtime with move stake introduced a breaking change, because of what Shibuya dApp staking is currently broken.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

