### PR TITLE
Disable zk bridges and network selection

### DIFF
--- a/src/components/bridge/BridgeSelection.vue
+++ b/src/components/bridge/BridgeSelection.vue
@@ -191,9 +191,9 @@
           <p v-if="!isZkEvm" class="text--bridge-details">
             {{ $t('bridge.ethereumBridge.remark') }}
           </p>
-          <p v-if="!nativeBridgeEnabled" class="text--bridge-details">
+          <!-- <p v-if="!nativeBridgeEnabled" class="text--bridge-details">
             {{ $t('bridge.bridgeMaintenanceMode') }}
-          </p>
+          </p> -->
         </div>
 
         <div class="column--selection">
@@ -230,9 +230,9 @@
           <p v-if="!isEnableLzBridge" class="text--bridge-details">
             {{ $t('bridge.astarBridge.remark') }}
           </p>
-          <p v-if="!layerZeroBridgeEnabled" class="text--bridge-details">
+          <!-- <p v-if="!layerZeroBridgeEnabled" class="text--bridge-details">
             {{ $t('bridge.bridgeMaintenanceMode') }}
-          </p>
+          </p> -->
         </div>
 
         <div class="column--selection">

--- a/src/components/header/modals/SelectNetwork.vue
+++ b/src/components/header/modals/SelectNetwork.vue
@@ -12,6 +12,7 @@
       </button>
 
       <button
+        :disabled="true"
         class="card--astar box--hover--active"
         :class="selNetworkId === endpointKey.ASTAR_ZKEVM && 'border--active'"
         @click="setSelNetwork(endpointKey.ASTAR_ZKEVM)"

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,8 +1,8 @@
 import { CcipNetworkName } from './modules/ccip-bridge';
 
 // Bridges
-export const nativeBridgeEnabled = true;
-export const layerZeroBridgeEnabled = true;
+export const nativeBridgeEnabled = false;
+export const layerZeroBridgeEnabled = false;
 export const layerSwapBridgeEnabled = false;
 export const celerBridgeEnabled = true;
 export const omniBridgeEnabled = true;


### PR DESCRIPTION
**Pull Request Summary**

Disabled zkEVM bridges and network selection. I didn't completely remove all zk related components and logic just in case we will need to re-enable the network access for a short period of time.
I will remove all zk related code later.

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
