### PR TITLE
pin firebase-tools version to 13.35.1 in PR preview workflow

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -21,3 +21,4 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_ASTAR_APPS_STAGING }}'
           channelId: live
           projectId: astar-apps-staging
+          firebaseToolsVersion: 13.35.1

--- a/.github/workflows/pull-request-preview.yml
+++ b/.github/workflows/pull-request-preview.yml
@@ -36,6 +36,7 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_ASTAR_APPS }}'
           projectId: astar-apps
+          firebaseToolsVersion: 13.35.1
   e2etest:
     permissions:
       checks: write


### PR DESCRIPTION
**Pull Request Summary**

> Fix Firebase Hosted Preview URL workflow with downgrading firebase-tools version

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**

- Fix Firebase Hosted Preview URL workflow with downgrading firebase-tools version
