### PR TITLE
Fix for a bridge tooltip being partially hidden

### DIFF
--- a/src/components/assets/SideAds.vue
+++ b/src/components/assets/SideAds.vue
@@ -69,6 +69,7 @@ export default defineComponent({
 }
 .swiper {
   overflow: hidden;
+  z-index: 0;
 }
 .card--swiper {
   border: solid 1px $gray-2;


### PR DESCRIPTION
**Pull Request Summary**

The bridge to Soneium was partially hidden by ads

BEFORE
<img width="317" alt="image" src="https://github.com/user-attachments/assets/b1b8e942-c878-45d0-8c2f-ab3cfc3e9f98" />

NOW
<img width="459" alt="image" src="https://github.com/user-attachments/assets/29617a2d-3622-4189-a71d-2a31244d610d" />




**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
