### PR TITLE
fix: updated XCM logix to apply V5 for withdrawal transactions

### DIFF
--- a/src/modules/xcm/index.ts
+++ b/src/modules/xcm/index.ts
@@ -286,9 +286,9 @@ export let xcmChainObj: XcmChainObj = {
     img: require('/src/assets/img/token/pha.png'),
     parachainId: parachainIds.PHALA,
     endpoints: [
-      'wss://api.phala.network/ws',
       'wss://phala-rpc.dwellir.com',
       'wss://phala.api.onfinality.io/public-ws',
+      'wss://rpc.helikon.io/phala',
     ],
     subscan: 'https://phala.subscan.io',
     isAstarNativeToken: true,

--- a/src/modules/xcm/index.ts
+++ b/src/modules/xcm/index.ts
@@ -298,10 +298,7 @@ export let xcmChainObj: XcmChainObj = {
     relayChain: Chain.POLKADOT,
     img: require('/src/assets/img/token/bnc.svg'),
     parachainId: parachainIds.BIFROST_POLKADOT,
-    endpoints: [
-      'wss://hk.p.bifrost-rpc.liebi.com/ws',
-      'wss://bifrost-polkadot.api.onfinality.io/public-ws',
-    ],
+    endpoints: ['wss://hk.p.bifrost-rpc.liebi.com/ws'],
     chopsticksEndpoint: 'ws://localhost:9947',
     subscan: 'https://bifrost.subscan.io',
     isAstarNativeToken: true,

--- a/src/v2/repositories/implementations/xcm/AstarXcmRepository.ts
+++ b/src/v2/repositories/implementations/xcm/AstarXcmRepository.ts
@@ -4,7 +4,7 @@ import { getPubkeyFromSS58Addr } from '@astar-network/astar-sdk-core';
 import { XcmTokenInformation } from 'src/modules/xcm';
 import { container } from 'src/v2/common';
 import { ExtrinsicPayload, IApi, IApiFactory } from 'src/v2/integration';
-import { Asset, Chain, ethWalletChains, XcmChain } from 'src/v2/models';
+import { Asset, ethWalletChains, XcmChain } from 'src/v2/models';
 import { Symbols } from 'src/v2/symbols';
 import { XcmRepository } from '../XcmRepository';
 
@@ -40,14 +40,10 @@ export class AstarXcmRepository extends XcmRepository {
     const isWithdrawAssets = token.id !== this.astarNativeTokenId;
 
     const asset = isWithdrawAssets
-      ? {
-          Concrete: await this.fetchAssetConfig(from, token, endpoint),
-        }
+      ? await this.fetchAssetConfig(from, token, endpoint)
       : {
-          Concrete: {
-            interior: 'Here',
-            parents: new BN(0),
-          },
+          interior: 'Here',
+          parents: new BN(0),
         };
 
     const assets = {

--- a/src/v2/repositories/implementations/xcm/InterlayXcmRepository.ts
+++ b/src/v2/repositories/implementations/xcm/InterlayXcmRepository.ts
@@ -13,7 +13,6 @@ import { XcmRepository } from '../XcmRepository';
  * Used to transfer assets from Interlay/Kintsugi
  */
 export class InterlayXcmRepository extends XcmRepository {
-
   constructor() {
     const defaultApi = container.get<IApi>(Symbols.DefaultApi);
     const apiFactory = container.get<IApiFactory>(Symbols.ApiFactory);

--- a/src/v2/repositories/implementations/xcm/PendulumXcmRepository.ts
+++ b/src/v2/repositories/implementations/xcm/PendulumXcmRepository.ts
@@ -16,7 +16,6 @@ const TOKEN_IDS: Record<string, any> = {
 };
 
 export class PendulumXcmRepository extends XcmRepository {
-
   constructor() {
     const defaultApi = container.get<IApi>(Symbols.DefaultApi);
     const apiFactory = container.get<IApiFactory>(Symbols.ApiFactory);


### PR DESCRIPTION
**Pull Request Summary**

* fix: updated XCM logix to apply V5 for withdrawal tranasactions

Transaction examples:
https://astar.subscan.io/xcm_message/polkadot-7dc7b91e57b228b018540701bd9d093d7644e9e1
https://astar.subscan.io/xcm_message/polkadot-76379a51b3c65ea7f85335bec0d273b95938158d
https://astar.blockscout.com/tx/0x6800b26c3e0c530b23ff42511f385de97ebde0eb1fbf257e21e6c4f34568832d (withdrawal from EVM)

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices
