### PR TITLE
Fetch period end block from Token API

### DIFF
--- a/src/staking-v3/hooks/usePeriodStats.ts
+++ b/src/staking-v3/hooks/usePeriodStats.ts
@@ -47,7 +47,7 @@ export function usePeriodStats(period: Ref<number>) {
     return combinedData.filter((data) => data !== undefined) as DappStatistics[];
   });
 
-  const getPeriodEndBlock = async (period: number, currentPeriod: number): Promise<number> => {
+  const getPeriodEndBlock = async (period: number): Promise<number> => {
     try {
       const tokenApiRepository = container.get<ITokenApiRepository>(Symbols.TokenApiRepository);
       const networkName = currentNetworkName.value.toLowerCase();
@@ -68,10 +68,7 @@ export function usePeriodStats(period: Ref<number>) {
     );
 
     const allDappsId = allDapps.value.map((dapp) => dapp.chain.id);
-    const periodEndBlock = await getPeriodEndBlock(
-      period.value,
-      protocolState.value?.periodInfo.number ?? period.value
-    );
+    const periodEndBlock = await getPeriodEndBlock(period.value);
     const [stats, totalIssuance, periodInfo, stakes] = await Promise.all([
       repository.getStakingPeriodStatistics(currentNetworkName.value.toLowerCase(), period.value),
       balancesRepository.getTotalIssuance(block),
@@ -113,10 +110,7 @@ export function usePeriodStats(period: Ref<number>) {
         eraLengths.value.standardEraLength
       ) {
         try {
-          const periodEndBlock = await getPeriodEndBlock(
-            period.value,
-            protocolState.value?.periodInfo.number ?? period.value
-          );
+          const periodEndBlock = await getPeriodEndBlock(period.value);
           const stakingService = container.get<IDappStakingService>(Symbols.DappStakingServiceV3);
 
           const block = Math.min(periodEndBlock, currentBlock.value) - 1;

--- a/src/staking-v3/hooks/usePeriodStats.ts
+++ b/src/staking-v3/hooks/usePeriodStats.ts
@@ -47,31 +47,17 @@ export function usePeriodStats(period: Ref<number>) {
     return combinedData.filter((data) => data !== undefined) as DappStatistics[];
   });
 
-  const getPeriodEndBlock = (period: number, currentPeriod: number): number => {
-    const periodStartBlock = PERIOD1_START_BLOCKS.get(currentNetworkName.value.toLowerCase());
+  const getPeriodEndBlock = async (period: number, currentPeriod: number): Promise<number> => {
+    try {
+      const tokenApiRepository = container.get<ITokenApiRepository>(Symbols.TokenApiRepository);
+      const networkName = currentNetworkName.value.toLowerCase();
+      const range = await tokenApiRepository.getPeriodBlockRange(networkName, period);
 
-    if (periodStartBlock) {
-      if (period < currentPeriod) {
-        const {
-          standardEraLength,
-          standardErasPerBuildAndEarnPeriod,
-          standardErasPerVotingPeriod,
-        } = eraLengths.value;
-        return (
-          periodStartBlock +
-          (standardErasPerBuildAndEarnPeriod + standardErasPerVotingPeriod) *
-            standardEraLength *
-            period -
-          1
-        );
-      }
-
+      return range.end ?? currentBlock.value;
+    } catch (error) {
+      console.error('Failed to get period end block', error);
       return currentBlock.value;
     }
-
-    throw new Error(
-      `Can't determine dApp staking start block for network ${currentNetworkName.value}`
-    );
   };
 
   const calculateTvlRatio = async (block: number): Promise<void> => {
@@ -82,14 +68,15 @@ export function usePeriodStats(period: Ref<number>) {
     );
 
     const allDappsId = allDapps.value.map((dapp) => dapp.chain.id);
+    const periodEndBlock = await getPeriodEndBlock(
+      period.value,
+      protocolState.value?.periodInfo.number ?? period.value
+    );
     const [stats, totalIssuance, periodInfo, stakes] = await Promise.all([
       repository.getStakingPeriodStatistics(currentNetworkName.value.toLowerCase(), period.value),
       balancesRepository.getTotalIssuance(block),
       dappStakingRepository.getCurrentEraInfo(block),
-      dappStakingRepository.getContractsStake(
-        allDappsId,
-        getPeriodEndBlock(period.value, protocolState.value?.periodInfo.number ?? period.value)
-      ),
+      dappStakingRepository.getContractsStake(allDappsId, periodEndBlock),
     ]);
 
     // Update skates receiver from indexer although the indexer data is correct, we are using on chain data
@@ -126,7 +113,7 @@ export function usePeriodStats(period: Ref<number>) {
         eraLengths.value.standardEraLength
       ) {
         try {
-          const periodEndBlock = getPeriodEndBlock(
+          const periodEndBlock = await getPeriodEndBlock(
             period.value,
             protocolState.value?.periodInfo.number ?? period.value
           );

--- a/src/v2/repositories/ITokenApiRepository.ts
+++ b/src/v2/repositories/ITokenApiRepository.ts
@@ -45,4 +45,11 @@ export interface ITokenApiRepository {
    * @param network Network name.
    */
   getTokeIssuanceHistory(network: string): Promise<TokenIssuance[]>;
+
+  /**
+   * Gets the block range for the given dApp staking period.
+   * @param network Network name.
+   * @param period Period number.
+   */
+  getPeriodBlockRange(network: string, period: number): Promise<{ start: number; end?: number }>;
 }

--- a/src/v2/repositories/implementations/TokenApiRepository.ts
+++ b/src/v2/repositories/implementations/TokenApiRepository.ts
@@ -58,4 +58,17 @@ export class TokenApiRepository implements ITokenApiRepository {
       return [];
     }
   }
+
+  public async getPeriodBlockRange(
+    network: string,
+    period: number
+  ): Promise<{ start: number; end?: number }> {
+    try {
+      const url = `${TokenApiRepository.BaseUrl}/v3/${network}/dapps-staking/get-period-range/${period}`;
+      const response = await axios.get<{ start: number; end?: number }>(url);
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to fetch block range for period ${period} on network ${network}`);
+    }
+  }
 }


### PR DESCRIPTION
**Pull Request Summary**

Fetch period end block from Token API.
Current period end block calculation became invalid because of async backing.

**Check list**

- [ ] contains breaking changes
- [x] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

