### PR TITLE
Fix for remaining locked balance

### DIFF
--- a/src/staking-v3/hooks/useVote.ts
+++ b/src/staking-v3/hooks/useVote.ts
@@ -9,7 +9,7 @@ import { useDappStakingNavigation } from './useDappStakingNavigation';
 
 export function useVote(dapps: Ref<DappVote[]>, dappToMoveTokensFromAddress?: string) {
   const { currentAccount } = useAccount();
-  const { useableBalance, lockedInDemocracy } = useBalance(currentAccount);
+  const { useableBalance } = useBalance(currentAccount);
   const {
     ledger,
     totalStake,

--- a/src/staking-v3/hooks/useVote.ts
+++ b/src/staking-v3/hooks/useVote.ts
@@ -28,7 +28,7 @@ export function useVote(dapps: Ref<DappVote[]>, dappToMoveTokensFromAddress?: st
   let remainingLockedTokensInitial = BigInt(0);
 
   const lockedInDappStaking = computed<bigint>(() => ledger?.value?.locked ?? BigInt(0));
-  const locked = computed<bigint>(() => max(lockedInDappStaking.value, lockedInDemocracy.value));
+  const locked = computed<bigint>(() => lockedInDappStaking.value);
 
   const totalStakeAmount = computed<bigint>(() =>
     ethers.utils

--- a/src/v2/repositories/implementations/IdentityRepository.ts
+++ b/src/v2/repositories/implementations/IdentityRepository.ts
@@ -35,14 +35,18 @@ export class IdentityRepository implements IIdentityRepository {
     if (!api.query.identity) {
       return undefined;
     }
-    const result = await api.query.identity.identityOf<Option<Tuple>>(address);
+    const result = await api.query.identity.identityOf<Option<PalletIdentityRegistration>>(address);
 
     if (result.isNone) {
       return undefined;
     }
 
     const unwrappedResult = result.unwrapOrDefault();
-    const identity = <PalletIdentityRegistration>unwrappedResult[0];
+    const identity = <PalletIdentityRegistration>unwrappedResult;
+    if (!identity || !identity.info) {
+      return undefined;
+    }
+
     const data = new IdentityData(u8aToString(identity.info.display.asRaw), []);
     identity.info.additional.forEach((x) => {
       // Seems dirty. The problem here is that some raw data is treated as ASCII and some as bytes


### PR DESCRIPTION
**Pull Request Summary**

By mistake amount locked in democracy was treated as locked in dApp staking 👎 

Also fixed identity info loading (used only on Shibuya)

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

