### PR TITLE
fix: display `Available amount after staking` correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ astar-collator
 # Chopstick binaries
 db.sqlite*
 .vercel
+CLAUDE.md

--- a/src/staking-v3/hooks/useVote.ts
+++ b/src/staking-v3/hooks/useVote.ts
@@ -81,9 +81,17 @@ export function useVote(dapps: Ref<DappVote[]>, dappToMoveTokensFromAddress?: st
       return availableToMove.value - totalStakeAmount.value;
     }
 
-    return remainingLockedTokens.value >= BigInt(0)
-      ? BigInt(useableBalance.value) + remainingLockedTokens.value + availableToMove.value
-      : BigInt(useableBalance.value) - abs(remainingLockedTokens.value) + availableToMove.value;
+    // Calculate available balance after staking
+    // Use the initial remaining locked tokens (before staking amount input)
+    // to avoid double-counting the staking amount reduction
+    const availableBalance = BigInt(useableBalance.value);
+    const initialRemainingLocked = max(remainingLockedTokensInitial, BigInt(0));
+    const actualAvailable = availableBalance + availableToMove.value + initialRemainingLocked;
+
+    // Return the balance after subtracting the staking amount
+    const afterStaking = actualAvailable - totalStakeAmount.value;
+
+    return afterStaking;
   });
 
   const amountToUnstake = computed<bigint>(() =>


### PR DESCRIPTION
**Pull Request Summary**

* fix: display Available amount after staking correctly

**Check list**

- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tested on mobile devices

**This pull request makes the following changes:**

**Fixes**

The fix now uses `remainingLockedTokensInitial` instead of the reactive `remainingLockedTokens.value`. This ensures that:

  1. The initial locked tokens value is captured before any staking amount is entered (this happens in the watch at the bottom of this file)
  2. When calculating `availableToVoteDisplay`, we use this fixed initial value
  3. This prevents the double-counting issue where the staking amount was reducing both `remainingLockedTokens` and being subtracted again in the display calculation

  Now when you enter a staking amount:
  - The available balance will simply decrease by that amount
  - The remaining locked tokens display will update correctly
 
=Before=

* The `Available amount after staking` should be 558 as the inputted amount is 100, but the result is 458, it decreased the amount twice.

<img width="674" height="387" alt="image" src="https://github.com/user-attachments/assets/35ec74fb-cf5b-415c-8db0-14088be0bd3a" />

<img width="660" height="465" alt="image" src="https://github.com/user-attachments/assets/2f763c41-225b-4d17-8320-a5bea17c62f2" />

=After=

<img width="986" height="581" alt="image" src="https://github.com/user-attachments/assets/fc04dc3c-b6fb-4d84-b3a9-5385e0b80ba7" />
